### PR TITLE
Coincidence of Wants query

### DIFF
--- a/cowprotocol/coincidence_of_wants/.sqlfluff
+++ b/cowprotocol/coincidence_of_wants/.sqlfluff
@@ -1,0 +1,4 @@
+[sqlfluff:templater:jinja:context]
+start_time='2024-08-01 12:00'
+end_time='2024-08-02 12:00'
+blockchain='ethereum'

--- a/cowprotocol/coincidence_of_wants/balance_changes_4021257.sql
+++ b/cowprotocol/coincidence_of_wants/balance_changes_4021257.sql
@@ -1,0 +1,223 @@
+-- This is a base query for monitoring balance changes on CoW Protocol
+--
+-- The query collects all balance changes to the settlemenr contract. Those changes can comw from
+-- - erc20 transfers
+-- - native transfers
+-- - chain specific event like deposits and widrawals
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+--
+-- The columns of the result are:
+-- - block_time: time of settlement transaction
+-- - tx_hash: settlement transaction hash
+-- - token_address: address of token with a balance change. contract address for erc20 tokens,
+--   0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee for native token
+-- - sender: origin of transfers sending tokens to the settlement contract,
+--   0x0000000000000000000000000000000000000000 for deposits/withdrawals
+-- - receiver: destination of transfer sending tokens from the settlement contract,
+--   0x0000000000000000000000000000000000000000 for deposits/withdrawals
+-- - amount: value of the balance change in atoms of the token
+
+-- 1) data on all chains
+-- 1.1) erc20
+-- 1.2) native transfers
+
+-- 1.1) all the erc20 transfers to/from cow amms
+with erc20_transfers as (
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        "from" as sender,
+        to as receiver,
+        value as amount
+    from erc20_{{blockchain}}.evt_transfer
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 in ("from", to)
+),
+-- 1.2) all native token transfers
+native_transfers as (
+    select
+        block_time,
+        tx_hash,
+        0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee as token_address,
+        "from" as sender,
+        to as receiver,
+        value as amount
+    from {{blockchain}}.traces
+    where block_time >= cast('{{start_time}}' as timestamp) and block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and value > cast(0 as uint256)
+        and success = true
+        and 0x9008d19f58aabd9ed0d60971565aa8510560ab41 in (to, "from")
+),
+
+-- 2) chain specific data
+-- 2.1) ethereum
+-- special treatmet of
+-- 2.1.1) WETCH
+-- 2.1.2) sDAI
+
+-- 2.1.1) all deposit and withdrawal events for WETH
+weth_deposits_withdrawals_ethereum as (
+    -- deposits (contract deposits ETH to get WETH)
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x0000000000000000000000000000000000000000 as sender,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
+        wad as amount
+    from zeroex_ethereum.WETH9_evt_Deposit
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+    union
+    -- withdrawals (contract withdraws ETH by returning WETH)
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
+        0x0000000000000000000000000000000000000000 as receiver,
+        wad as amount
+    from zeroex_ethereum.WETH9_evt_Withdrawal
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and src = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+-- 2.1.2) all deposit and withdrawal events for sDAI
+sdai_deposits_withdraws_ethereum as (
+    -- deposits
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x0000000000000000000000000000000000000000 as sender,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
+        shares as amount_wei
+    from maker_ethereum.SavingsDai_evt_Deposit
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+    union
+    -- withdraws
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
+        0x0000000000000000000000000000000000000000 as receiver,
+        shares as amount_wei
+    from maker_ethereum.SavingsDai_evt_Withdraw
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+special_balance_changes_ethereum as (
+    select * from weth_deposits_withdrawals_ethereum
+    union all
+    select * from sdai_deposits_withdraws_ethereum
+),
+
+-- 2.2) gnosis
+-- special treatmet of
+-- 2.2.1) WXDAI
+-- 2.2.2) sDAI
+
+-- 2.2.1) all deposit and withdrawal events for WXDAI
+wxdai_deposits_withdrawals_gnosis as (
+    -- deposits (contract deposits XDAI to get WXDAI)
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x0000000000000000000000000000000000000000 as sender,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
+        wad as amount
+    from wxdai_gnosis.WXDAI_evt_Deposit
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+    union
+    -- withdrawals (contract withdraws XDAI by returning WXDAI)
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
+        0x0000000000000000000000000000000000000000 as receiver,
+        wad as amount
+    from wxdai_gnosis.WXDAI_evt_Withdrawal
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and src = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+-- 2.2.2) all deposit and withdrawal events for sDAI
+sdai_deposits_withdraws_gnosis as (
+    -- deposits
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x0000000000000000000000000000000000000000 as sender,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
+        shares as amount_wei
+    from sdai_gnosis.SavingsXDai_evt_Deposit
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+    union
+    -- withdraws
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
+        0x0000000000000000000000000000000000000000 as receiver,
+        shares as amount_wei
+    from sdai_gnosis.SavingsXDai_evt_Withdraw
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+special_balance_changes_gnosis as (
+    select * from wxdai_deposits_withdrawals_gnosis
+    union all
+    select * from sdai_deposits_withdraws_gnosis
+),
+
+-- 2.3) arbitrum
+-- special treatmet of
+-- 2.3.1) WETH
+
+-- 2.3.1) all deposit and withdrawal events for WETH
+weth_deposits_withdrawals_arbitrum as (
+    -- deposits (contract deposits ETH to get WETH)
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x0000000000000000000000000000000000000000 as sender,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
+        wad as amount
+    from mindgames_weth_arbitrum.WETH9_evt_Deposit
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+    union
+    -- withdrawals (contract withdraws ETH by returning WETH)
+    select
+        evt_block_time as block_time,
+        evt_tx_hash as tx_hash,
+        contract_address as token_address,
+        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
+        0x0000000000000000000000000000000000000000 as receiver,
+        wad as amount
+    from mindgames_weth_arbitrum.WETH9_evt_Withdrawal
+    where evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
+        and src = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+special_balance_changes_arbitrum as (
+    select * from weth_deposits_withdrawals_arbitrum
+)
+
+-- combine results
+select * from erc20_transfers
+union all
+select * from native_transfers
+union all
+select * from special_balance_changes_{{blockchain}}

--- a/cowprotocol/coincidence_of_wants/balance_changes_4021257.sql
+++ b/cowprotocol/coincidence_of_wants/balance_changes_4021257.sql
@@ -60,7 +60,7 @@ native_transfers as (
 -- 2) chain specific data
 -- 2.1) ethereum
 -- special treatmet of
--- 2.1.1) WETCH
+-- 2.1.1) WETH
 -- 2.1.2) sDAI
 
 -- 2.1.1) all deposit and withdrawal events for WETH

--- a/cowprotocol/coincidence_of_wants/classified_balance_changes_4021306.sql
+++ b/cowprotocol/coincidence_of_wants/classified_balance_changes_4021306.sql
@@ -1,0 +1,80 @@
+-- This query is part of a base query for computing CoWs
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+--
+-- The query tags all transfers to and from the settlement contract as one of
+-- - user_in: amounts sent by users, tokens flowing into the settlement contract
+-- - user_out: amount sent to users, tokens flowing out of the settlement contract
+-- - amm_in: tokens flowing into the settlement contract but coming from users
+-- - amm_out:tokens flowing out of the settlement contract but not towards users
+-- - slippage_in: final imbalance of the settlement contract if that imbalance is positive
+-- - slippage_out: final imbalance of the settlement contract of that imbalance is negative
+--
+-- The classification into user transfers and amm transfers depends on a clear separation of addresses into
+-- trader addresses and amm addresses. If an address is used in a trade, all interactions with that address
+-- are classified as user transfers, even in other transactions.
+--
+-- The common edge case of the settlement contract acting as a trader is implicitly handled sa follows:
+-- The settlement contract will appear as a trader. There will be a transfer from the settlement contract to itself.
+-- The corresponding balance change is accounted for as 'user_in'.
+-- This behavior will be wrong when an order is created with receiver set to the settlement contract.
+
+with filtered_trades as (
+    select
+        *
+    from cow_protocol_{{blockchain}}.trades
+    where block_time >= cast('{{start_time}}' as timestamp) and block_time < cast('{{end_time}}' as timestamp)
+),
+traders as (
+    select
+        trader as sender,
+        receiver
+    from filtered_trades
+),
+balance_changes as (
+    select
+        *
+    from "query_4021257(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+),
+-- classify balance changes
+balance_changes_with_types as (
+    select
+        block_time,
+        tx_hash,
+        token_address,
+        amount,
+        case
+            -- user in
+            when (sender in (select sender from traders) -- transfer coming from a trader
+                or sender = 0x40a50cf069e992aa4536211b23f286ef88752187) -- transfer coming from ETH flow
+                and receiver = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 -- transfer going to the settlement contract
+            then 'user_in'
+            -- user out
+            when receiver in (select receiver from traders) -- transfer going to a trader
+                and sender = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 -- transfer coming from the settlement contract
+            then 'user_out'
+            -- amm in
+            when receiver = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+            then 'amm_in'
+            -- amm out
+            when sender = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+            then 'amm_out'
+        end as transfer_type
+    from balance_changes
+),
+slippage as (
+    select
+        block_time,
+        tx_hash,
+        token_address,
+        case when amount >= 0 then cast(amount as uint256) else cast(-amount as uint256) end as amount,
+        case when amount >= 0 then 'slippage_in' else 'slippage_out' end as transfer_type
+    from "query_4021644(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+)
+
+select * from balance_changes_with_types
+union all
+select * from slippage

--- a/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
@@ -56,8 +56,7 @@ cow_volume_per_batch as (
         sum(slippage_in) as slippage_in,
         sum(slippage_out) as slippage_out,
         sum(user_out * naive_cow_potential) as naive_cow_potential_volume,
-        sum(user_out * naive_cow) as naive_cow_volume,
-        sum((user_in + user_out) * naive_cow_averaged) as naive_cow_averaged_volume
+        sum(user_out * naive_cow) as naive_cow_volume
     from cow_per_token_usd
     group by block_time, tx_hash
 )

--- a/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
@@ -6,6 +6,9 @@
 --  {{blockchain}} - network to run the analysis on
 --
 -- It computes a CoW fraction per batch by averaging the CoW fractions from query 4021555 weighted by usd volume
+--
+-- The query is based on a Master's Thesis by Vigan Lladrovci
+-- https://wwwmatthes.in.tum.de/pages/y9xcjv094zhn/Master-s-Thesis-Vigan-Lladrovci
 
 with cow_per_token as (
     select * from "query_4021555(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"

--- a/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
@@ -1,0 +1,66 @@
+-- This query computes Coincidence of Wants fractions on CoW Protocol for individual tokens
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+--
+-- It computes a CoW fraction per batch by averaging the CoW fractions from query 4021555 weighted by usd volume
+
+with cow_per_token as (
+    select * from "query_4021555(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+),
+-- get prices from trades table
+token_prices as (
+    select * from "query_4031637(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+),
+-- join token amounts with prices from trades table
+cow_per_token_with_prices as (
+    select
+        cpt.*,
+        token_price
+    from cow_per_token cpt
+    left outer join token_prices tp
+    on tp.tx_hash = cpt.tx_hash and tp.token_address = cpt.token_address
+),
+-- convert amounts to dollar values
+cow_per_token_usd as (
+    select
+        block_time,
+        tx_hash,
+        token_address,
+        token_price * user_in as user_in,
+        token_price * user_out as user_out,
+        token_price * amm_in as amm_in,
+        token_price * amm_out as amm_out,
+        token_price * slippage_in as slippage_in,
+        token_price * slippage_out as slippage_out,
+        naive_cow_potential,
+        naive_cow,
+        naive_cow_averaged
+    from cow_per_token_with_prices
+),
+-- aggregate token volumes
+cow_volume_per_batch as (
+    select
+        block_time,
+        tx_hash,
+        sum(user_in) as user_in,
+        sum(user_out) as user_out,
+        sum(amm_in) as amm_in,
+        sum(amm_out) as amm_out,
+        sum(slippage_in) as slippage_in,
+        sum(slippage_out) as slippage_out,
+        sum(user_out * naive_cow_potential) as naive_cow_potential_volume,
+        sum(user_out * naive_cow) as naive_cow_volume,
+        sum((user_in + user_out) * naive_cow_averaged) as naive_cow_averaged_volume
+    from cow_per_token_usd
+    group by block_time, tx_hash
+)
+-- compute cow values per batch
+select
+    *,
+    case when user_out > 0 then naive_cow_potential_volume / user_out else null end as naive_cow_potential,
+    case when user_out > 0 then naive_cow_volume / user_out else null end as naive_cow,
+    case when user_in + user_out > 0 then naive_cow_averaged_volume / (user_in + user_out) else null end as naive_cow_averaged
+from cow_volume_per_batch

--- a/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
@@ -16,6 +16,9 @@
 --   This quantity indicates what fraction of the amount bought and sold is not traded via AMMs or internalizations (showing as slippage).
 --
 -- The query also returns aggregated amounts for user_in, user_out, amm_in, amm_out, slippage_in, slippage_out for all tokens.
+--
+-- The query is based on a Master's Thesis by Vigan Lladrovci
+-- https://wwwmatthes.in.tum.de/pages/y9xcjv094zhn/Master-s-Thesis-Vigan-Lladrovci
 
 with aggregate_transfers_with_types as (
     select

--- a/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
@@ -46,6 +46,5 @@ transfers_per_token as (
 select
     *,
     case when user_out > 0 then least(1.0 * user_in / user_out, 1.0) end as naive_cow_potential,
-    case when user_out > 0 then greatest(least(1.0 * (user_in - amm_out - slippage_in) / user_out, 1.0), 0.0) end as naive_cow,
-    case when user_in + user_out > 0 then greatest(1.0 * ((user_in + user_out) - (amm_in + amm_out) - (slippage_in + slippage_out)) / (user_in + user_out), 0.0) end as naive_cow_averaged
+    case when user_out > 0 then greatest(least(1.0 * (user_in - amm_out - slippage_in) / user_out, 1.0), 0.0) end as naive_cow
 from transfers_per_token

--- a/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
@@ -1,0 +1,50 @@
+-- This query computes Coincidence of Wants fractions on CoW Protocol for individual tokens
+--
+-- It uses transfer information from query 4021306.
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+--
+-- The cow metrics computed are
+-- - naive_cow_potential: min(user_in / user_out, 1)
+--   This quantity indicates what fraction of the amount bought of a token is sold by other users.
+-- - naive_cow: max(min((user_in - amm_out - slippage_in) / user_out, 1), 0)
+--   This quantity indicates what fraction of the amount bought is not traded via AMMs or internalizations (showing as slippage).
+-- - naive_cow_averaged: max(((user_in + user_out) - (amm_in + amm_out) - (slippage_in + slippage_out)) / (user_in + user_out), 0)
+--   This quantity indicates what fraction of the amount bought and sold is not traded via AMMs or internalizations (showing as slippage).
+--
+-- The query also returns aggregated amounts for user_in, user_out, amm_in, amm_out, slippage_in, slippage_out for all tokens.
+
+with aggregate_transfers_with_types as (
+    select
+        block_time,
+        tx_hash,
+        token_address,
+        sum(amount) as amount,
+        transfer_type
+    from "query_4021306(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+    group by block_time, tx_hash, token_address, transfer_type
+),
+transfers_per_token as (
+    select
+        block_time,
+        tx_hash,
+        token_address,
+        sum(case when transfer_type = 'user_in' then cast(amount as int256) else 0 end) as user_in, -- sum is selecting the only entry
+        sum(case when transfer_type = 'user_out' then cast(amount as int256) else 0 end) as user_out,
+        sum(case when transfer_type = 'amm_in' then cast(amount as int256) else 0 end) as amm_in,
+        sum(case when transfer_type = 'amm_out' then cast(amount as int256) else 0 end) as amm_out,
+        sum(case when transfer_type = 'slippage_in' then cast(amount as int256) else 0 end) as slippage_in,
+        sum(case when transfer_type = 'slippage_out' then cast(amount as int256) else 0 end) as slippage_out
+    from aggregate_transfers_with_types
+    group by block_time, tx_hash, token_address
+)
+
+select
+    *,
+    case when user_out > 0 then least(1.0 * user_in / user_out, 1.0) else null end as naive_cow_potential,
+    case when user_out > 0 then greatest(least(1.0 * (user_in - amm_out - slippage_in) / user_out, 1.0), 0.0) else null end as naive_cow,
+    case when user_in + user_out > 0 then greatest(1.0 * ((user_in + user_out) - (amm_in + amm_out) - (slippage_in + slippage_out)) / (user_in + user_out), 0.0) else null end as naive_cow_averaged
+from transfers_per_token

--- a/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_token_4021555.sql
@@ -22,11 +22,12 @@ with aggregate_transfers_with_types as (
         block_time,
         tx_hash,
         token_address,
-        sum(amount) as amount,
-        transfer_type
+        transfer_type,
+        sum(amount) as amount
     from "query_4021306(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
     group by block_time, tx_hash, token_address, transfer_type
 ),
+
 transfers_per_token as (
     select
         block_time,
@@ -44,7 +45,7 @@ transfers_per_token as (
 
 select
     *,
-    case when user_out > 0 then least(1.0 * user_in / user_out, 1.0) else null end as naive_cow_potential,
-    case when user_out > 0 then greatest(least(1.0 * (user_in - amm_out - slippage_in) / user_out, 1.0), 0.0) else null end as naive_cow,
-    case when user_in + user_out > 0 then greatest(1.0 * ((user_in + user_out) - (amm_in + amm_out) - (slippage_in + slippage_out)) / (user_in + user_out), 0.0) else null end as naive_cow_averaged
+    case when user_out > 0 then least(1.0 * user_in / user_out, 1.0) end as naive_cow_potential,
+    case when user_out > 0 then greatest(least(1.0 * (user_in - amm_out - slippage_in) / user_out, 1.0), 0.0) end as naive_cow,
+    case when user_in + user_out > 0 then greatest(1.0 * ((user_in + user_out) - (amm_in + amm_out) - (slippage_in + slippage_out)) / (user_in + user_out), 0.0) end as naive_cow_averaged
 from transfers_per_token

--- a/cowprotocol/coincidence_of_wants/cow_total_4025865.sql
+++ b/cowprotocol/coincidence_of_wants/cow_total_4025865.sql
@@ -14,6 +14,7 @@ with t as (
         sum(user_in + user_out) as total_volume_in_out
     from "query_4025739(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
 )
+
 select
     *,
     naive_cow_potential_volume / total_volume as naive_cow_potential_fraction,

--- a/cowprotocol/coincidence_of_wants/cow_total_4025865.sql
+++ b/cowprotocol/coincidence_of_wants/cow_total_4025865.sql
@@ -9,15 +9,12 @@ with t as (
     select
         sum(naive_cow_potential_volume) as naive_cow_potential_volume,
         sum(naive_cow_volume) as naive_cow_volume,
-        sum(naive_cow_averaged_volume) as naive_cow_averaged_volume,
-        sum(user_out) as total_volume,
-        sum(user_in + user_out) as total_volume_in_out
+        sum(user_out) as total_volume
     from "query_4025739(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
 )
 
 select
     *,
     naive_cow_potential_volume / total_volume as naive_cow_potential_fraction,
-    naive_cow_volume / total_volume as naive_cow_fraction,
-    naive_cow_averaged_volume / total_volume_in_out as naive_cow_averaged_fraction
+    naive_cow_volume / total_volume as naive_cow_fraction
 from t

--- a/cowprotocol/coincidence_of_wants/cow_total_4025865.sql
+++ b/cowprotocol/coincidence_of_wants/cow_total_4025865.sql
@@ -1,0 +1,22 @@
+-- aggregate volume and cow volume from query 4025739
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+
+with t as (
+    select
+        sum(naive_cow_potential_volume) as naive_cow_potential_volume,
+        sum(naive_cow_volume) as naive_cow_volume,
+        sum(naive_cow_averaged_volume) as naive_cow_averaged_volume,
+        sum(user_out) as total_volume,
+        sum(user_in + user_out) as total_volume_in_out
+    from "query_4025739(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+)
+select
+    *,
+    naive_cow_potential_volume / total_volume as naive_cow_potential_fraction,
+    naive_cow_volume / total_volume as naive_cow_fraction,
+    naive_cow_averaged_volume / total_volume_in_out as naive_cow_averaged_fraction
+from t

--- a/cowprotocol/coincidence_of_wants/imbalances_4021644.sql
+++ b/cowprotocol/coincidence_of_wants/imbalances_4021644.sql
@@ -1,0 +1,16 @@
+-- This a base query for computing token imbalances of the CoW Protocol contract
+--
+-- It is based on query 4021257 and aggregates the transfers from that query into imbalances per token
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+
+select
+    block_time,
+    tx_hash,
+    token_address,
+    sum(case when receiver = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 then cast(amount as int256) else -cast(amount as int256) end) as amount -- this classifies transfers from the settlement contract to itself as incoming transfers
+from "query_4021257(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+group by block_time, tx_hash, token_address

--- a/cowprotocol/coincidence_of_wants/token_prices_4031637.sql
+++ b/cowprotocol/coincidence_of_wants/token_prices_4031637.sql
@@ -1,0 +1,72 @@
+-- This query returns prices for tokens traded via CoW Protocol
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+--
+-- The returned table has columns:
+-- - block_time: time a a settlement transaction
+-- - tx_hash: settlement transaction hash
+-- - token_address:
+-- - token_price: price in USD of one _atom_ of a token
+--
+-- Prices are either fetched from the trades table which contains Dune prices if they exist,
+-- or computes them from the exchange rate from the trade if the second traded token has a price on Dune.
+-- If no trade with a dune price exists for a token, the price is set to zero.
+--
+-- Prices are in USD _per atom_ to avoid special casing of trades involving tokens without an entry in erc20 tables.
+-- This fits to naturally to other queries using amounts in atoms. If amounts in _units_ of a token are used,
+-- prices need to be scaled using decimals of the token.
+
+with filtered_trades as (
+    select
+        *
+    from cow_protocol_{{blockchain}}.trades
+    where block_time >= cast('{{start_time}}' as timestamp) and block_time < cast('{{end_time}}' as timestamp)
+),
+
+token_prices_from_trades as (
+    select
+        block_time,
+        tx_hash,
+        sell_token_address,
+        buy_token_address,
+        order_uid,
+        sell_price * units_sold / atoms_sold as token_price_sell, -- in usd per atom
+        buy_price * units_bought / atoms_bought as token_price_buy,
+        buy_price * units_bought / atoms_bought * atoms_bought / atoms_sold  as token_price_backup_sell,
+        sell_price * units_sold / atoms_sold * atoms_sold / atoms_bought  as token_price_backup_buy
+    from filtered_trades
+),
+token_prices_from_trades_sell as (
+    select
+        block_time,
+        tx_hash,
+        sell_token_address as token_address,
+        token_price_sell as token_price,
+        token_price_backup_sell as token_price_backup
+    from token_prices_from_trades
+),
+token_prices_from_trades_buy as (
+    select
+        block_time,
+        tx_hash,
+        buy_token_address as token_address,
+        token_price_buy as token_price,
+        token_price_backup_buy as token_price_backup
+    from token_prices_from_trades
+),
+token_prices_all as (
+    select * from token_prices_from_trades_sell
+    union all
+    select * from token_prices_from_trades_buy
+)
+
+select
+    block_time,
+    tx_hash,
+    token_address,
+    coalesce(max(token_price), avg(token_price_backup), 0) as token_price
+from token_prices_all
+group by block_time, tx_hash, token_address

--- a/cowprotocol/coincidence_of_wants/token_prices_4031637.sql
+++ b/cowprotocol/coincidence_of_wants/token_prices_4031637.sql
@@ -20,8 +20,7 @@
 -- prices need to be scaled using decimals of the token.
 
 with filtered_trades as (
-    select
-        *
+    select *
     from cow_protocol_{{blockchain}}.trades
     where block_time >= cast('{{start_time}}' as timestamp) and block_time < cast('{{end_time}}' as timestamp)
 ),
@@ -35,10 +34,11 @@ token_prices_from_trades as (
         order_uid,
         sell_price * units_sold / atoms_sold as token_price_sell, -- in usd per atom
         buy_price * units_bought / atoms_bought as token_price_buy,
-        buy_price * units_bought / atoms_bought * atoms_bought / atoms_sold  as token_price_backup_sell,
-        sell_price * units_sold / atoms_sold * atoms_sold / atoms_bought  as token_price_backup_buy
+        buy_price * units_bought / atoms_bought * atoms_bought / atoms_sold as token_price_backup_sell,
+        sell_price * units_sold / atoms_sold * atoms_sold / atoms_bought as token_price_backup_buy
     from filtered_trades
 ),
+
 token_prices_from_trades_sell as (
     select
         block_time,
@@ -48,6 +48,7 @@ token_prices_from_trades_sell as (
         token_price_backup_sell as token_price_backup
     from token_prices_from_trades
 ),
+
 token_prices_from_trades_buy as (
     select
         block_time,
@@ -57,6 +58,7 @@ token_prices_from_trades_buy as (
         token_price_backup_buy as token_price_backup
     from token_prices_from_trades
 ),
+
 token_prices_all as (
     select * from token_prices_from_trades_sell
     union all

--- a/cowprotocol/coincidence_of_wants/token_prices_4031637.sql
+++ b/cowprotocol/coincidence_of_wants/token_prices_4031637.sql
@@ -32,10 +32,10 @@ token_prices_from_trades as (
         sell_token_address,
         buy_token_address,
         order_uid,
-        sell_price * units_sold / atoms_sold as token_price_sell, -- in usd per atom
-        buy_price * units_bought / atoms_bought as token_price_buy,
-        buy_price * units_bought / atoms_bought * atoms_bought / atoms_sold as token_price_backup_sell,
-        sell_price * units_sold / atoms_sold * atoms_sold / atoms_bought as token_price_backup_buy
+        sell_value_usd / atoms_sold as token_price_sell, -- in usd per atom
+        buy_value_usd / atoms_bought as token_price_buy,
+        buy_value_usd / atoms_sold as token_price_backup_sell,
+        sell_value_usd / atoms_bought as token_price_backup_buy
     from filtered_trades
 ),
 


### PR DESCRIPTION
This PR adds queries for computing Coincidence of Wants (CoWs) per batch.

The approach to CoWs follows a [master's thesis](https://wwwmatthes.in.tum.de/pages/y9xcjv094zhn/Master-s-Thesis-Vigan-Lladrovci) by Vigan Lladrovci. It is based on aggregated amounts transferred in and out of the settlement contract by users and other sources (AMMs, PMM, ...). This gives a metric for CoWs and for potential for CoWs for batches. The main idea is to aggregate per token bought in a batch the difference of the total usd volume of that token sold and the total volume sent towards AMMs. Aggregated over all tokens in a batch, this quantity can be compared to the total volume.

The original approach had problems taking internalizations into account. and excluded such batches from its analysis. Here, the approach is modified to handle such cases.

### Most important formulas

Per token, the CoW fraction
```
naive_cow = (user_in - amm_out - slippage_in) / user_out
```
is computed, capped at 1 from above and 0 from below. This fraction can be used to compute the CoW volume per batch
```
naive_cow_volume = sum(token_price * user_out * naive_cow)
```
and a CoW fraction per batch
```
naive_cow_volume / total_volume
```
This means, the weighted average by usd volume of user_out over all bought tokens is  the CoW value per batch.

## Queries

There are six queries to compute CoW fractions per batch, and one query aggregating batch values into a total. (Dashed squares and lines correspond to potential future queries.)

![CoWs drawio(1)](https://github.com/user-attachments/assets/c362bcc8-3eed-40f5-9a20-2d5188ebd870)

- `balance_changes`: This query collects all balance changes by looking at erc20 transfers, native token transfers, and additional changes from e.g. deposit and withdrawal events. A similar query is used for monitoring CoW AMMs. I do not know how to combine those queries, though, as I do not know how to programmatically choose a parameter from within a query. If that were possible, this query could be parametrized by a list of addresses and that list would be chosen to only contain the settlement contract in the CoW use case.
- `imbalances`: This query aggregates balance changes into one signed value per token. This query should compute the same values as https://github.com/cowprotocol/token-imbalances for raw token imbalances. The edge case of the protocol trading is handles consistently with the current slippage accounting: even though the buffer values are reduced significantly (fees are withdrawn from the contract), the imbalances only account for unexpected changes by counting transfers from the settlement contract to itself as incoming transfers.
- `classified_balance_changes`: This query classifies all balance changes into the categories `user_in`, `user_out`, `amm_in`, and `amm_out`. Additionally it adds the remaining imbalance computed in the `imbalance` query as `slippage_in` or `slippage_out` depending on sign.
- `cow_per_token`: This query computes CoW fractions per token. One should be cautious in interpreting this value. It does not have much meaning on its own (e.g. because the symmetry between buy and sell is broken) but can be turned into a meaningful aggregate value per batch.
- `token_prices`: This query computes token prices for tokens bought and sold by users from Dune and the exchange rate of trades. Prices are in USD per _atom_ of the token. Instead of joining on Dune data, it uses the `cow_protocol_{{blockchain}}.trades` table which contains Dune USD prices if they exist. If the USD price does not exist, a backup price is recovered from the price of the other traded token and the effective exchange rate of the trade. If multiple trades give such a price for a token, the average is used. If there is no price nor backup price, the price is set to zero. This seems to be rare though (below 1% of tokens).
- `cow_per_batch`: This query computes CoW fractions and CoW volumes per batch. If combines CoWs per token with USD volumes, where prices come from `token_prices`.
- `cow_total`: This query just aggregates numbers from `cow_per_batch` over the full time window.

All queries are parameterized by network (`blockchain`), start time (`start_time`, inclusive), and end time (`end_time`, exclusive). Computing CoW fractions for one month is reasonably fast. I have not checked the query with larger time windows. Running the query for individual transactions is not possible. Instead, a time window containing the transaction should be used and the result filtered on the hash.

## Open issues

- The naming `naive_cow` could/should be changed to just `cow` or some more descriptive name. I do not expect there to be one true definition of CoWs. And if there is, it will probably not be easy to compute it on Dune.
- I am computing a symmetrized version of `naive_cow` called `naive_cow_averaged`. This was in an attempt to translate the CoW metric to individual orders. I do not think this to be possible anymore, so one might as well remove those quantities. (Edit: There might be a way to define per order CoWs (see edit below) but it does not require a new metric for per token CoWs.)
- Translating this metric to individual orders will not be possible in general. At least there are examples, where missing information on which incoming and outgoing transfers to AMMs are connected leads to misclassification. One can still do correlations experiments (e.g. "are larger CoW fractions correlated to use of CoW AMMs?"). (Edit: It is possible using Shapley values, but not something we would want to do on Dune. And it might not really mean what we would want it to mean.)
- I have not accounted for fees in computing slippage or user amounts. This could create a bias in final numbers. For example, if large fees are charged, the volume incoming from users might be a lot larger than the volume outgoing to users. If fees are charged in buy tokens, that can increase CoW fractions. Since fees can be almost of the same order of magnitude as CoW volume, fees might have to be accounted for somehow.
- Some queries might also be useful in for slippage. The main thing missing would be better prices (and for more tokens) and correct accounting of fees.
- ~I have not applied any systematic formatting yet.~ (Basic sqlfluff formatting is applied now.)
