### PR TITLE
Update query to use hardcoded values for colocated solvers

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/.sqlfluff
+++ b/cowprotocol/accounting/rewards/mainnet/.sqlfluff
@@ -2,4 +2,4 @@
 start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
 vouch_cte_name=valid_vouches,named_results
-
+time='2024-08-27 00:00:00'

--- a/cowprotocol/accounting/rewards/mainnet/reduced_bonding_pools_query_4065709.sql
+++ b/cowprotocol/accounting/rewards/mainnet/reduced_bonding_pools_query_4065709.sql
@@ -1,0 +1,20 @@
+-- Query that hardcodes all existing reduced CoW DAO bonding pools that
+--  are currently valid at CoW Protocol.
+with
+reduced_bonding_pools as (
+    select
+        from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool_address,
+        'Reduced-CoW-DAO' as pool_name,
+        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver_address,
+        timestamp '2024-08-21 07:15:00' as creation_date
+    union distinct
+    select
+        from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool_address,
+        'Reduced-CoW-DAO' as pool_name,
+        from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver,
+        timestamp '2024-07-25 07:42:00' as creation_date
+)
+
+select *
+from
+    reduced_bonding_pools

--- a/cowprotocol/accounting/rewards/mainnet/reduced_bonding_pools_query_4065709.sql
+++ b/cowprotocol/accounting/rewards/mainnet/reduced_bonding_pools_query_4065709.sql
@@ -5,13 +5,19 @@ reduced_bonding_pools as (
     select
         from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool_address,
         'Reduced-CoW-DAO' as pool_name,
-        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver_address,
+        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver_address, -- prod-Barter
+        timestamp '2024-08-21 07:15:00' as creation_date
+    union distinct
+    select
+        from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool_address,
+        'Reduced-CoW-DAO' as pool_name,
+        from_hex('0xA6A871b612bCE899b1CbBad6E545e5e47Da98b87') as solver_address,  -- barn-Barter
         timestamp '2024-08-21 07:15:00' as creation_date
     union distinct
     select
         from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool_address,
         'Reduced-CoW-DAO' as pool_name,
-        from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver,
+        from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver,  -- prod-Copium_Capital
         timestamp '2024-07-25 07:42:00' as creation_date
 )
 

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_alternative_query_4066633.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_alternative_query_4066633.sql
@@ -1,0 +1,123 @@
+-- This query computes which solvers need to pay service fee
+-- by breaking down the calculation in small (and somewhat tedious) steps
+-- We stress the query is not efficient (and recomputes same things along the way)
+-- but we believe it is at least straightforward to check its correctness, and given
+-- that it's fast anyways, we decided to go with this.
+
+-- Parameters:
+-- {{time}}: the date that we want to evaluate whether the service fee needs to be applied (needs to be start of accounting period)
+
+with
+-- we first compute all solvers of the CoW DAO bonding pool (this includes the ones that have their own reduced subpool)
+-- and only look at their names. Note that this is necessary to identify when a solver first joined the pool, as many solvers
+-- have changes accounts multiple times 
+active_cow_dao_solver_names as (
+    select distinct substring(solver_name, 6, 100) as solver_name
+    -- here we remove the "prod-" and "barn-" prefix so as to only work with the actual solver name,
+    from
+        "query_1541516(vouch_cte_name='named_results',end_time='{{time}}')"
+    where
+        pool_address = 0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6 -- CoW DAO bonding pool address
+),
+
+-- we now take one step back and look at all solver accounts (not only the active ones) that have joined the CoW DAO bonding pool at some point,
+-- and we recover the date of them joining
+all_cow_dao_solvers as (
+    select
+        s.name as solver_name,
+        v.solver,
+        v.evt_block_time,
+        v.evt_block_number
+    from
+        cow_protocol_ethereum.VouchRegister_evt_Vouch as v
+    inner join cow_protocol_ethereum.solvers as s on v.solver = s.address
+    where
+        v.bondingPool = 0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6
+),
+
+-- we now join the previous two tables so that we can associate the name of an active solver under the CoW DAO bonding pool
+-- with its "real" join time, i.e., the first time that it joined the pool (using potentially an account that changed on the way)
+join_date_per_cow_dao_solver as (
+    select
+        solver_name,
+        min(evt_block_time) as join_time
+    from
+        all_cow_dao_solvers
+    group by
+        solver_name
+),
+
+-- we now create an intermediate table to put back the "prod/barn" prefix to the solver names
+-- as this will make it easier to join with the rest of the tables that we want to do join
+active_cow_dao_solvers_join_date as (
+    select
+        concat('prod-', jdpcds.solver_name) as solver_name,
+        jdpcds.join_time
+    from
+        join_date_per_cow_dao_solver as jdpcds
+    inner join active_cow_dao_solver_names as acdsn on jdpcds.solver_name = acdsn.solver_name
+    union distinct
+    select
+        concat('barn-', jdpcds.solver_name) as solver_name,
+        jdpcds.join_time
+    from
+        join_date_per_cow_dao_solver as jdpcds
+    inner join active_cow_dao_solver_names as acdsn on jdpcds.solver_name = acdsn.solver_name
+),
+
+-- this is now the first calculation of whether a solver in the CoW DAO bonding pool needs to pay a service fee.
+-- note that we assume here no solver has its own subpool, and we will correct that later on.
+active_cow_dao_solvers_service_fee as (
+    select
+        solver_name,
+        case
+            when join_time > date_add('month', -6, cast('{{time}}' as timestamp)) then false
+            else true
+        end as pay_service_fee
+    from
+        active_cow_dao_solvers_join_date
+),
+
+-- we now create a table of all active solvers, not just the ones in the CoW DAO bonding pool,
+-- where we still pretend there are no reduced bonding pools
+all_active_solvers_service_fee_prelim as (
+    select
+        v.solver,
+        v.reward_target,
+        v.pool_address,
+        v.pool_name,
+        v.solver_name,
+        coalesce(acdssf.pay_service_fee, false) as pay_service_fee
+    from
+        "query_1541516(vouch_cte_name='named_results',end_time='{{time}}')" as v
+    left outer join active_cow_dao_solvers_service_fee as acdssf on v.solver_name = acdssf.solver_name
+),
+
+-- we now create another table that only looks at the reduced subpools and computes whether the solvers
+-- with subpools need to pay a service fee or not
+reduced_bonding_pool_solvers_service_fee as (
+    select
+        pool_name,
+        solver_address,
+        case
+            when creation_date > date_add('month', -3, cast('{{time}}' as timestamp)) then false
+            else true
+        end as pay_service_fee
+    from query_4065709
+),
+
+-- finally, we join the prelim table with the above table and we define that a solver with a subpool needs to pay
+-- a servive fee only if it is at least 6 months in the CoW DAO bonding pool AND >= 3 months have passed since the creation
+-- of the subpool
+all_active_solvers_service_fee_final as (
+    select
+        p.solver,
+        p.reward_target,
+        p.pool_address,
+        p.solver_name,
+        coalesce(rbp.pool_name, p.pool_name) as pool_name,
+        coalesce(rbp.pay_service_fee and p.pay_service_fee, p.pay_service_fee) as pay_service_fee
+    from all_active_solvers_service_fee_prelim as p left outer join reduced_bonding_pool_solvers_service_fee as rbp on p.solver = rbp.solver_address
+)
+
+select * from all_active_solvers_service_fee_final

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -6,8 +6,8 @@ colocated_solvers as (
         'prod-Barter' as solver_name,
         'Reduced-Bonding' as pool_name,
         from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool,
-        timestamp '2024-08-21 07:15:00' as joined_on,
-        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver
+        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver,
+        timestamp '2024-08-21 07:15:00' as joined_on
 ),
 
 bonding_pools (pool, pool_name, initial_funder) as (

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -5,9 +5,9 @@ colocated_solvers as (
     select
         'prod-Barter' as solver_name,
         'Reduced-Bonding' as pool_name,
+        timestamp '2024-08-21 07:15:00' as joined_on,
         from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool,
-        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver,
-        timestamp '2024-08-21 07:15:00' as joined_on
+        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver
 ),
 
 bonding_pools (pool, pool_name, initial_funder) as (
@@ -105,7 +105,7 @@ joined_on_with_colocated as (
         null as evt_index,
         1 as rk,
         true as active
-    from colocated_solvers c
+    from colocated_solvers as c
 ),
 
 latest_vouches as (
@@ -215,17 +215,18 @@ named_results as (
         jd.pool_name,
         jd.pool,
         jd.joined_on,
-        date_diff('day', date(jd.joined_on), date(now())) as days_in_pool,
-        concat(environment, '-', s.name) as solver_name
+        concat(environment, '-', s.name) as solver_name,
+        date_diff('day', date(jd.joined_on), date(now())) as days_in_pool
     from
         joined_on as jd
     inner join cow_protocol_ethereum.solvers as s on jd.solver = s.address
-    inner join valid_vouches
-        as vv on jd.solver = vv.solver
-    and jd.pool = vv.pool
-    
+    inner join valid_vouches as vv
+        on
+            jd.solver = vv.solver
+            and jd.pool = vv.pool
+
     union all
-    
+
     select
         c.solver,
         c.pool_name,
@@ -233,7 +234,7 @@ named_results as (
         c.joined_on,
         c.solver_name,
         date_diff('day', date(c.joined_on), date(now())) as days_in_pool
-    from colocated_solvers c
+    from colocated_solvers as c
 ),
 
 ranked_named_results as (

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -215,8 +215,8 @@ named_results as (
         jd.pool_name,
         jd.pool,
         jd.joined_on,
-        concat(environment, '-', s.name) as solver_name,
-        date_diff('day', date(jd.joined_on), date(now())) as days_in_pool
+        date_diff('day', date(jd.joined_on), date(now())) as days_in_pool,
+        concat(environment, '-', s.name) as solver_name
     from
         joined_on as jd
     inner join cow_protocol_ethereum.solvers as s on jd.solver = s.address

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -19,7 +19,7 @@ colocated_solvers as (
     select
         'prod-Copium_Capital' as solver_name,
         'Reduced-Bonding' as pool_name,
-        timestamp '7-25-24 07:42:00' as joined_on,
+        timestamp '2024-07-25 07:42:00' as joined_on,
         from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool,
         from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver
 ),

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -8,6 +8,20 @@ colocated_solvers as (
         timestamp '2024-08-21 07:15:00' as joined_on,
         from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool,
         from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver
+    union all
+    select
+        'barn-Barter' as solver_name,
+        'Reduced-Bonding' as pool_name,
+        timestamp '2024-08-21 07:15:00' as joined_on,
+        from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool,
+        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver
+    union all
+    select
+        'prod-Copium_Capital' as solver_name,
+        'Reduced-Bonding' as pool_name,
+        timestamp '7-25-24 07:42:00' as joined_on,
+        from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool,
+        from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver
 ),
 
 bonding_pools (pool, pool_name, initial_funder) as (

--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -1,5 +1,15 @@
 with
 
+-- Add colocated solvers here
+colocated_solvers as (
+    select
+        'prod-Barter' as solver_name,
+        'Reduced-Bonding' as pool_name,
+        from_hex('0xB6113c260aD0a8A086f1E31c5C92455252A53Fb8') as pool,
+        timestamp '2024-08-21 07:15:00' as joined_on,
+        from_hex('0xC7899Ff6A3aC2FF59261bD960A8C880DF06E1041') as solver
+),
+
 bonding_pools (pool, pool_name, initial_funder) as (
     select
         from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool,
@@ -71,6 +81,31 @@ joined_on_data as (
         initial_vouches as iv
     where
         iv.rk = 1
+),
+
+joined_on_with_colocated as (
+    select
+        solver,
+        reward_target,
+        pool,
+        evt_block_number,
+        evt_index,
+        rk,
+        active
+    from joined_on_data
+
+    union all
+
+    -- Add hardcoded colocated solvers
+    select
+        c.solver,
+        null as reward_target,
+        c.pool,
+        null as evt_block_number,
+        null as evt_index,
+        1 as rk,
+        true as active
+    from colocated_solvers c
 ),
 
 latest_vouches as (
@@ -169,7 +204,7 @@ joined_on as (
         bp.pool_name,
         b.time as joined_on
     from
-        joined_on_data as jd
+        joined_on_with_colocated as jd
     inner join ethereum.blocks as b on jd.evt_block_number = b.number
     inner join bonding_pools as bp on jd.pool = bp.pool
 ),
@@ -188,6 +223,17 @@ named_results as (
     inner join valid_vouches
         as vv on jd.solver = vv.solver
     and jd.pool = vv.pool
+    
+    union all
+    
+    select
+        c.solver,
+        c.pool_name,
+        c.pool,
+        c.joined_on,
+        c.solver_name,
+        date_diff('day', date(c.joined_on), date(now())) as days_in_pool
+    from colocated_solvers c
 ),
 
 ranked_named_results as (
@@ -219,12 +265,9 @@ filtered_named_results as (
         rnr.pool,
         rnr.joined_on,
         rnr.days_in_pool,
+        rnr.pool_name,
         case
-            when rnr.solver_name_count > 1 then 'Colocation'
-            else rnr.pool_name
-        end as pool_name,
-        case
-            when rnr.solver_name_count > 1 then date_add('month', 3, rnr.joined_on) -- Add 3 month grace period for colocated solvers
+            when rnr.pool_name = 'Reduced-Bonding' then date_add('month', 3, rnr.joined_on) -- Add 3 month grace period for colocated solvers
             else greatest(
                 date_add('month', 6, rnr.joined_on), -- Add 6 month grace period to joined_on for non colocated solvers
                 timestamp '2024-08-20 00:00:00' -- Introduction of CIP-48


### PR DESCRIPTION
This PR addresses issue #12 and updates the CIP-48 query to use hard-coded values for colocated drivers. 

This change also updates the logic for calculating the 3 month grace period for colocated solvers. Now, the logic only sets the grace period if they are manually marked as being in a reduced bonding pool.

Currently hardcoding all colocated solvers. Updates have been made to the CMS to allow us to get this information in a GitHub action, but since that's not live yet I'm adding these manually.