### PR TITLE
Fix CoW query

### DIFF
--- a/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
+++ b/cowprotocol/coincidence_of_wants/cow_per_batch_4025739.sql
@@ -37,7 +37,6 @@ cow_per_token_usd as (
         token_address,
         naive_cow_potential,
         naive_cow,
-        naive_cow_averaged,
         token_price * user_in as user_in,
         token_price * user_out as user_out,
         token_price * amm_in as amm_in,
@@ -68,6 +67,5 @@ cow_volume_per_batch as (
 select
     *,
     case when user_out > 0 then naive_cow_potential_volume / user_out end as naive_cow_potential,
-    case when user_out > 0 then naive_cow_volume / user_out end as naive_cow,
-    case when user_in + user_out > 0 then naive_cow_averaged_volume / (user_in + user_out) end as naive_cow_averaged
+    case when user_out > 0 then naive_cow_volume / user_out end as naive_cow
 from cow_volume_per_batch


### PR DESCRIPTION
This PR removes symmetriced cow vaules from the bcow per batch query.

In a refactoring, this value was removed in all queries except for this one.

I am not sure how to checkf whether the query work fine if not for copying changes manually to Dune. Just copying the whole query messes with parameters for me.