### PR TITLE
[CoW AMM Performance] 10k growth for daily rebalancing portfolio

### DIFF
--- a/cow_amm/daily_rebalancing_4055484.sql
+++ b/cow_amm/daily_rebalancing_4055484.sql
@@ -1,0 +1,49 @@
+-- Computes the balances and current value of a counterfactual portfolio that invests 10k evenly into two tokens and re-balances once a day to keep a 50:50 exposure
+-- Parameters
+--  {{token_a}} - either token of the desired uni pool
+--  {{token_b}} - other token of the desired uni pool
+--  {{start}} - date as of which the analysis should run
+
+with recursive balances (day, balance0, balance1) as (
+    -- Base case: $10k are invested evenly into token_a and token_b at the opening price of the start day
+    select
+        date(timestamp '{{start}}'),
+        10000 / 2 / p1.price_open, -- Initial balance in token_a
+        10000 / 2 / p2.price_open  -- Initial balance in token_b
+    from prices.usd_daily as p1
+    inner join prices.usd_daily as p2
+        on
+            p1.day = date(timestamp '{{start}}')
+            and p1.day = p2.day
+            and p1.blockchain = 'ethereum'
+            and p2.blockchain = 'ethereum'
+            and p1.contract_address = {{token_a}}
+            and p2.contract_address = {{token_b}}
+
+    union all
+
+    -- Recursive case: Compute the next day's balances according to previous day's closing price and reinvest half into each token
+    select
+        b.day + interval '1' day,
+        (balance0 * p1.price_close + balance1 * p2.price_close) / 2 / p1.price_close, -- Updated balance in token_a
+        (balance0 * p1.price_close + balance1 * p2.price_close) / 2 / p2.price_close  -- Updated balance in token_b
+    from balances as b
+    inner join prices.usd_daily as p1
+        on b.day = p1.day and p1.contract_address = {{token_a}}
+    inner join prices.usd_daily as p2
+        on b.day = p2.day and p2.contract_address = {{token_b}}
+    where b.day < date(now())
+)
+
+-- Multiply daily balances with end of day closing price to get current value
+select
+    b.day,
+    b.balance0,
+    b.balance1,
+    (b.balance0 * p1.price_close) + (b.balance1 * p2.price_close) as current_value
+from balances as b
+inner join prices.usd_daily as p1
+    on b.day = p1.day and p1.contract_address = {{token_a}}
+inner join prices.usd_daily as p2
+    on b.day = p2.day and p2.contract_address = {{token_b}}
+order by 1 desc;

--- a/cow_amm/daily_rebalancing_4055484.sql
+++ b/cow_amm/daily_rebalancing_4055484.sql
@@ -53,6 +53,6 @@ daily_price_change as (
 select
     day,
     -- SQL doesn't support PRODUCT() over (...), but luckily "the sum of logarithms" is equal to "logarithm of the product",
-    exp(sum(ln((p1 + p2) / 2)) over (order by day asc)) * 10000 as current_value
+    exp(sum(ln((p1 + p2) / 2)) over (order by day asc)) * 10000 as current_value_of_investment
 from daily_price_change
 order by 1 desc

--- a/cow_amm/daily_rebalancing_4055484.sql
+++ b/cow_amm/daily_rebalancing_4055484.sql
@@ -6,7 +6,9 @@
 
 -- Note: not using a simpler recursive approach due to Dune's recursion depth limitation.
 -- Current value of initial investment can be computed as the product of cumulative price changes per day, since
--- value(day+1) = value(day) * (p1.price(day+1)/p1.price(day) + p2.price(day+1) / p2.price(day))/2
+-- `value(day+1) = value(day) * (p1.price(day+1)/p1.price(day) + p2.price(day+1) / p2.price(day))/2`
+-- Thus, current_value can be computed using cumulative products of (sums of) daily price changes:
+-- `(p1.price(day+1)/p1.price(day) + p2.price(day+1)/p2.price(day))/2`
 
 -- limit the relevant date range
 with date_series as (


### PR DESCRIPTION
On top of the comparison with the Uniswap reference pool, another interesting reference for CoW AMM performance is the value that a daily rebalancing portfolio (ie a 50:50 ETF that re-allocates once a day) would have over time.

This query achieves this using a recursive SQL statement. It invests 10k on the starting day at the opening price, and then for every consecutive day takes the closing price of the previous day to assess its allocation and perform a rebalancing.

### Test Plan 

Dune run: https://dune.com/queries/4055484

To cross check, I printed the closing prices for each day and redid the calculation manually for a short time period.