### PR TITLE
Add block range, bonding pool and vouch queries

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/.sqlfluff
+++ b/cowprotocol/accounting/rewards/mainnet/.sqlfluff
@@ -1,4 +1,4 @@
 [sqlfluff:templater:jinja:context]
-start_time='2024-08-20 00:00'
-end_time='2024-08-27 00:00'
+start_time='2024-08-20 00:00:00'
+end_time='2024-08-27 00:00:00'
 

--- a/cowprotocol/accounting/rewards/mainnet/.sqlfluff
+++ b/cowprotocol/accounting/rewards/mainnet/.sqlfluff
@@ -1,0 +1,5 @@
+[sqlfluff:templater:jinja:context]
+start_time='2024-08-20 00:00'
+end_time='2024-08-27 00:00'
+vouch_cte_name=(named_results, valid_vouches)
+

--- a/cowprotocol/accounting/rewards/mainnet/.sqlfluff
+++ b/cowprotocol/accounting/rewards/mainnet/.sqlfluff
@@ -1,5 +1,4 @@
 [sqlfluff:templater:jinja:context]
 start_time='2024-08-20 00:00'
 end_time='2024-08-27 00:00'
-vouch_cte_name=named_results, valid_vouches
 

--- a/cowprotocol/accounting/rewards/mainnet/.sqlfluff
+++ b/cowprotocol/accounting/rewards/mainnet/.sqlfluff
@@ -1,5 +1,5 @@
 [sqlfluff:templater:jinja:context]
 start_time='2024-08-20 00:00'
 end_time='2024-08-27 00:00'
-vouch_cte_name=(named_results, valid_vouches)
+vouch_cte_name=named_results, valid_vouches
 

--- a/cowprotocol/accounting/rewards/mainnet/.sqlfluff
+++ b/cowprotocol/accounting/rewards/mainnet/.sqlfluff
@@ -1,4 +1,5 @@
 [sqlfluff:templater:jinja:context]
 start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
+vouch_cte_name=valid_vouches,named_results
 

--- a/cowprotocol/accounting/rewards/mainnet/block_number_interval_from_time_interval_query_3333356.sql
+++ b/cowprotocol/accounting/rewards/mainnet/block_number_interval_from_time_interval_query_3333356.sql
@@ -1,0 +1,5 @@
+select
+    min("number") as start_block,
+    max("number") as end_block
+from ethereum.blocks
+where time >= cast('{{start_time}}' as timestamp) and time < cast('{{end_time}}' as timestamp)

--- a/cowprotocol/accounting/rewards/mainnet/block_number_interval_from_time_interval_query_3333356.sql
+++ b/cowprotocol/accounting/rewards/mainnet/block_number_interval_from_time_interval_query_3333356.sql
@@ -1,3 +1,10 @@
+-- Base query to convert accounting period to block range.
+-- Convention throughout the accounting that is used is that we consider all auctions whose
+-- block deadline is in the block range this query returns
+-- Parameters:
+--  {{start_time}} - the start date timestamp for the accounting period  (inclusively)
+--  {{end_time}} - the end date timestamp for the accounting period (exclusively)
+
 select
     min("number") as start_block,
     max("number") as end_block

--- a/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
@@ -1,0 +1,21 @@
+with
+full_bonding_pools as (
+    select
+        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address,
+        'Gnosis' as pool_name,
+        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as funder
+    union distinct
+    select
+        from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool_address,
+        'CoW Services' as pool_name,
+        from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as funder
+    union distinct
+    select
+        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address,
+        'Project Blanc' as pool_name,
+        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as funder
+)
+
+select *
+from
+    full_bonding_pools

--- a/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
@@ -1,3 +1,5 @@
+-- Query that hardcodes all existing full bonding pools that
+--  are currently valid at CoW Protocol.
 with
 full_bonding_pools as (
     select

--- a/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
@@ -1,19 +1,19 @@
 with
 full_bonding_pools as (
     select
-        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address,
+        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool,
         'Gnosis' as pool_name,
-        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as funder
+        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as initial_funder
     union distinct
     select
-        from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool_address,
+        from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool,
         'CoW Services' as pool_name,
-        from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as funder
+        from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as initial_funder
     union distinct
     select
-        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address,
+        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool,
         'Project Blanc' as pool_name,
-        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as funder
+        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as initial_funder
 )
 
 select *

--- a/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
@@ -3,17 +3,17 @@
 with
 full_bonding_pools as (
     select
-        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool,
+        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address,
         'Gnosis' as pool_name,
         from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as initial_funder
     union distinct
     select
-        from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool,
-        'CoW Services' as pool_name,
+        from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool_address,
+        'CoW DAO' as pool_name,
         from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as initial_funder
     union distinct
     select
-        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool,
+        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address,
         'Project Blanc' as pool_name,
         from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as initial_funder
 )

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -1,0 +1,105 @@
+with
+
+last_block_before_timestamp as (
+    select max(number) from ethereum.blocks
+    where time < cast('{{end_time}}' as timestamp)
+),
+
+vouches as (
+    select
+        evt_block_number,
+        evt_index,
+        solver,
+        cowRewardTarget as reward_target,
+        pool,
+        sender,
+        True as active
+    from cow_protocol_ethereum.VouchRegister_evt_Vouch
+    inner join query_4056263
+        on
+            pool = pool_address
+            and sender = funder
+    where evt_block_number <= (select * from last_block_before_timestamp)
+),
+
+invalidations as (
+    select
+        evt_block_number,
+        evt_index,
+        solver,
+        Null as reward_target,  -- This is just ot align with vouches to take a union
+        pool,
+        sender,
+        False as active
+    from cow_protocol_ethereum.VouchRegister_evt_InvalidateVouch
+    inner join query_4056263
+        on
+            pool = pool_address
+            and sender = funder
+    where evt_block_number <= (select * from last_block_before_timestamp)
+),
+
+vouches_and_invalidations as (
+    select *
+    from
+        vouches
+    union distinct
+    select *
+    from invalidations
+),
+
+-- At this point we have excluded all arbitrary vouches (i.e. those not from initial funders of recognized pools)
+-- This ranks (solver, pool, sender) by most recent (vouch or invalidation)
+-- and yields as rank 1, the current "active" status of the triplet.
+ranked_vouches as (
+    select
+        *,
+        rank() over (
+            partition by solver, pool, sender
+            order by evt_block_number desc, evt_index desc
+        ) as rk
+    from vouches_and_invalidations
+),
+
+-- This will contain all latest active vouches,
+-- but could still contain solvers with multiplicity > 1 for different pools.
+-- Rank here again by solver, and time.
+current_active_vouches as (
+    select
+        *,
+        rank() over (
+            partition by solver
+            order by evt_block_number, evt_index
+        ) as time_rank
+    from ranked_vouches
+    where
+        rk = 1
+        and active = True
+),
+
+-- To filter for the case of "same solver, different pool",
+-- rank the current_active vouches and choose the earliest
+valid_vouches as (
+    select
+        solver,
+        reward_target,
+        pool
+    from current_active_vouches
+    where time_rank = 1
+),
+
+named_results as (
+    select
+        solver,
+        reward_target,
+        vv.pool as bonding_pool,
+        bp.name as pool_name,
+        concat(environment, '-', s.name) as solver_name
+    from valid_vouches as vv
+    inner join cow_protocol_ethereum.solvers as s
+        on address = solver
+    inner join query_4056263 as bp
+        on vv.pool = bp.pool_address
+)
+
+select * from {{vouch_cte_name}}

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -84,7 +84,7 @@ valid_vouches as (
     select
         solver,
         reward_target,
-        pool_addresss
+        pool_address
     from current_active_vouches
     where time_rank = 1
 ),

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -1,8 +1,10 @@
+-- Query that fetches the list of solver addresses that are active
+-- and are properly vouched for by a full bonding pool
+-- Parameters:
+--  {{end_time}} - the end date timestamp for the accounting period (exclusively)
 with
-
 last_block_before_timestamp as (
-    select max(number) from ethereum.blocks
-    where time < cast('{{end_time}}' as timestamp)
+    select end_block from "query_3333356(start_time='2018-01-01 00:00',end_time='{{end_time}}')"
 ),
 
 -- Query Logic Begins here!
@@ -44,8 +46,7 @@ invalidations as (
 -- This ranks (solver, pool, sender) by most recent (vouch or invalidation)
 -- and yields as rank 1, the current "active" status of the triplet.
 vouches_and_invalidations as (
-    select *
-    from vouches
+    select * from vouches
     union distinct
     select * from invalidations
 ),

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -4,7 +4,7 @@
 --  {{end_time}} - the end date timestamp for the accounting period (exclusively)
 with
 last_block_before_timestamp as (
-    select end_block from "query_3333356(start_time='2018-01-01 00:00',end_time='{{end_time}}')"
+    select end_block from "query_3333356(start_time='2018-01-01 00:00:00',end_time='{{end_time}}')"
 ),
 
 -- Query Logic Begins here!

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -93,14 +93,14 @@ named_results as (
     select
         solver,
         reward_target,
-        vv.pool as bonding_pool,
-        bp.name as pool_name,
+        vv.pool_address,
+        bp.pool_name,
         concat(environment, '-', s.name) as solver_name
     from valid_vouches as vv
     inner join cow_protocol_ethereum.solvers as s
-        on pool_address = solver
-    inner join bonding_pools as bp
-        on vv.pool = bp.pool
+        on s.address = solver
+    inner join query_4056263 as bp
+        on vv.pool_address = bp.pool_address
 )
 
 select * from {{vouch_cte_name}}

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -91,14 +91,14 @@ valid_vouches as (
 
 named_results as (
     select
-        solver,
-        reward_target,
+        vv.solver,
+        vv.reward_target,
         vv.pool_address,
         bp.pool_name,
         concat(environment, '-', s.name) as solver_name
     from valid_vouches as vv
     inner join cow_protocol_ethereum.solvers as s
-        on s.address = solver
+        on vv.solver = s.address
     inner join query_4056263 as bp
         on vv.pool_address = bp.pool_address
 )

--- a/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/mainnet/vouch_registry_query_1541516.sql
@@ -84,9 +84,23 @@ valid_vouches as (
     select
         solver,
         reward_target,
-        pool
+        pool_addresss
     from current_active_vouches
     where time_rank = 1
+),
+
+named_results as (
+    select
+        solver,
+        reward_target,
+        vv.pool as bonding_pool,
+        bp.name as pool_name,
+        concat(environment, '-', s.name) as solver_name
+    from valid_vouches as vv
+    inner join cow_protocol_ethereum.solvers as s
+        on pool_address = solver
+    inner join bonding_pools as bp
+        on vv.pool = bp.pool
 )
 
-select * from valid_vouches
+select * from {{vouch_cte_name}}


### PR DESCRIPTION
This PR migrates queries [3333356](https://dune.com/queries/3333356) and [1541516](https://dune.com/queries/1541516) to the repo. There are also some changes proposed for 1541516, that get rid of the parameter that passes the list of full bonding pools, and proposes instead to use a new query [4056263](https://dune.com/queries/4056263) to hardcode the full bonding pools.