### PR TITLE
[Draft, still broken] Fix ordering in rebalancing query

### DIFF
--- a/cowamm/profitability/10k_growth/daily_rebalancing_4055484.sql
+++ b/cowamm/profitability/10k_growth/daily_rebalancing_4055484.sql
@@ -55,4 +55,4 @@ select
     -- SQL doesn't support PRODUCT() over (...), but luckily "the sum of logarithms" is equal to "logarithm of the product",
     exp(sum(ln((p1 + p2) / 2)) over (order by day asc)) * 10000 as current_value_of_investment
 from daily_price_change
-order by 1 desc
+order by 1 asc


### PR DESCRIPTION
Ordering of the full table seems to not play well with the ordering in the cumulative sum.

Her I just changed the ordering from `desc` to `asc`.