### PR TITLE
[CoW AMM] Fix uni 10k growth query

### DIFF
--- a/cowamm/profitability/10k_growth/uni_v2_4047194.sql
+++ b/cowamm/profitability/10k_growth/uni_v2_4047194.sql
@@ -155,9 +155,9 @@ select
     lp_token_price,
     (
         -- Assess initial investment in lp tokens
-        select 10000 * lp_token_price as investment
+        select 10000 / lp_token_price as investment
         from lp_token_price
         where day = timestamp '{{start}}'
-    ) / lp_token_price as current_value_of_investment
+    ) * lp_token_price as current_value_of_investment
 from lp_token_price
 order by 1 desc


### PR DESCRIPTION
The original query was multiplying the initial assessment with the lp_token_price. This is wrong. If we want to compute the lp token amount we can get for 10k, we need to divide.

Similarly, in order to get the current value given the initial amount of lp tokens we need to multiply.