### PR TITLE
Use full bonding pools subquery in service fee tracker query

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
+++ b/cowprotocol/accounting/rewards/mainnet/service_fee_query_4017925.sql
@@ -24,16 +24,12 @@ colocated_solvers as (
         from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver
 ),
 
-bonding_pools (pool, pool_name, initial_funder) as (
+bonding_pools as (
     select
-        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool,
-        'Gnosis' as pool_name,
-        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as initial_funder
-    union all
-    select
-        from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool,
-        'CoW Services' as pool_name,
-        from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as initial_funder
+        pool_address as pool,
+        pool_name,
+        initial_funder
+    from "query_4056263"
 ),
 
 first_event_after_timestamp as (


### PR DESCRIPTION
This PR addresses a small issue with the hardcoded full bonds in the Service Fee Tracker query (4017925), where the Project Blanc bonding pool was missing. The issue is fixed by pulling the bonds from the dedicated query we have that computes all full bonds.