### PR TITLE
Update balance changes query

### DIFF
--- a/cowprotocol/accounting/token_imbalances/balance_changes_4021257.sql
+++ b/cowprotocol/accounting/token_imbalances/balance_changes_4021257.sql
@@ -162,7 +162,6 @@ special_balance_changes_ethereum as (
 -- 2.2) gnosis
 -- special treatmet of
 -- 2.2.1) WXDAI
--- 2.2.2) sDAI
 
 -- 2.2.1) all deposit and withdrawal events for WXDAI
 wxdai_deposits_withdrawals_gnosis as (
@@ -193,39 +192,8 @@ wxdai_deposits_withdrawals_gnosis as (
         and src = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
 ),
 
--- 2.2.2) all deposit and withdrawal events for sDAI
-sdai_deposits_withdraws_gnosis as (
-    -- deposits
-    select
-        evt_block_time as block_time,
-        evt_tx_hash as tx_hash,
-        contract_address as token_address,
-        0x0000000000000000000000000000000000000000 as sender,
-        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
-        shares as amount_wei
-    from sdai_gnosis.SavingsXDai_evt_Deposit
-    where
-        evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
-        and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
-    -- withdraws
-    select
-        evt_block_time as block_time,
-        evt_tx_hash as tx_hash,
-        contract_address as token_address,
-        0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
-        0x0000000000000000000000000000000000000000 as receiver,
-        shares as amount_wei
-    from sdai_gnosis.SavingsXDai_evt_Withdraw
-    where
-        evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
-        and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-),
-
 special_balance_changes_gnosis as ( -- noqa: ST03
     select * from wxdai_deposits_withdrawals_gnosis
-    union all
-    select * from sdai_deposits_withdraws_gnosis
 ),
 
 -- 2.3) arbitrum

--- a/cowprotocol/accounting/token_imbalances/balance_changes_4021257.sql
+++ b/cowprotocol/accounting/token_imbalances/balance_changes_4021257.sql
@@ -102,7 +102,7 @@ sdai_deposits_withdraws_ethereum as (
         contract_address as token_address,
         0x0000000000000000000000000000000000000000 as sender,
         0x9008d19f58aabd9ed0d60971565aa8510560ab41 as receiver,
-        shares as amount_wei
+        shares as amount
     from maker_ethereum.SavingsDai_evt_Deposit
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
@@ -115,7 +115,7 @@ sdai_deposits_withdraws_ethereum as (
         contract_address as token_address,
         0x9008d19f58aabd9ed0d60971565aa8510560ab41 as sender,
         0x0000000000000000000000000000000000000000 as receiver,
-        shares as amount_wei
+        shares as amount
     from maker_ethereum.SavingsDai_evt_Withdraw
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column


### PR DESCRIPTION
This PR changes two things about the balance changes query:
1. MKR burn and mint events on Ethereum Mainnet are now handled correctly.
2. Removes wrong special treatment of sDAI on Gnosis. Those events are always accompanied by all required transfer events. Adding additional transfers resulted in wrong balances. Those additional balance changes are removed now. Examples

It is easier to review the changes by looking at the three commits.

The query was tested by executing on the day range 2024-09-17--2024-09-19 and filtering on the following hashes:
1. [mint](https://etherscan.io/tx/0x92f1fe9f954efec5818c5039a59a5dd54949395149667a29b202e84adb22cfa0), [burn](https://etherscan.io/tx/0xee2f427596714793854d86a21fa2c88e1e38599a16fc58c747ae07e88fe0c78f)
2. [deposit](https://gnosisscan.io/tx/0x0ad630317c0326ffebb5eef10d8616faefab5af8c1a9d7a5e8e44141c63c2a1d), [withdraw](https://gnosisscan.io/tx/0xda6750469ecba9da408923a97c1a0a9fc5259f0e1890d559606f8263188512a8)

The new query ([copy](https://dune.com/queries/4080388)) adds one additional balance change in 1. and removes one balance change in 2.

This PR closes #41.