### PR TITLE
[EASY] Fix bug with filtering of slippage settlements

### DIFF
--- a/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
+++ b/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
@@ -90,7 +90,6 @@ raw_slippage_per_transaction as (
         sum(slippage_wei) as slippage_wei
     from raw_slippage_breakdown
     group by 1, 2
-    having bool_and(slippage_wei is not null or slippage_atoms = 0)
 )
 
 select * from {{raw_slippage_table_name}}

--- a/cowprotocol/accounting/slippage/slippage_4070065.sql
+++ b/cowprotocol/accounting/slippage/slippage_4070065.sql
@@ -34,7 +34,7 @@ slippage_per_transaction as (
         solver_address,
         sum(slippage_usd) as slippage_usd,
         sum(slippage_wei) as slippage_wei
-    from "query_4059683(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}',raw_slippage_table_name='raw_slippage_per_transaction')" as rs
+    from "query_4059683(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}',raw_slippage_table_name='raw_slippage_breakdown')" as rs
     inner join cow_protocol_{{blockchain}}.batches as b
         on rs.tx_hash = b.tx_hash
     where rs.tx_hash not in (select tx_hash from excluded_batches)


### PR DESCRIPTION
This PR fixes a bug with filtering of slippage per transaction and removes filtering from raw slippage.

Those queries had already been tested on Dune but some small changes had not been copied correctly to the PR.