### PR TITLE
[EASY] Change slippage wrapper for consistency with old slippage query

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_query_3427730.sql
+++ b/cowprotocol/accounting/slippage/slippage_query_3427730.sql
@@ -2,7 +2,7 @@ select
     solver_address,
     concat(environment, '-', name) as solver_name,
     slippage_usd as usd_value,
-    slippage_wei as eth_slippage_wei,
+    1.0 * slippage_wei as eth_slippage_wei,
     concat(
         '<a href="https://dune.com/queries/4070065',
         '&blockchain=ethereum',

--- a/cowprotocol/accounting/slippage/slippage_query_3427730.sql
+++ b/cowprotocol/accounting/slippage/slippage_query_3427730.sql
@@ -5,12 +5,12 @@ select
     slippage_wei as eth_slippage_wei,
     concat(
         '<a href="https://dune.com/queries/4070065',
-        '&blockchain={{blockchain}}',
+        '&blockchain=ethereum',
         '&start_time={{start_time}}',
         '&end_time={{end_time}}',
         '&slippage_table_name=slippage_per_transaction',
         '" target="_blank">link</a>'
     ) as slippage_per_transaction
-from "query_4070065(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}',slippage_table_name='slippage_per_solver')"
-inner join cow_protocol_{{blockchain}}.solvers
+from "query_4070065(blockchain='ethereum',start_time='{{start_time}}',end_time='{{end_time}}',slippage_table_name='slippage_per_solver')"
+inner join cow_protocol_ethereum.solvers
     on solver_address = address


### PR DESCRIPTION
This PR makes the slippage query wrapper consistent with the old slippage query.

- The `blockchain` parameter is set to `ethereum`. With this change, solver rewards does not have to add an additional parameter right now when querying slippage.
- The return type is changed to floating point numbers. This removes the need to have an additional conversion from within solver rewards.

This wrapper will be removed once we have to time to adapt the solver rewards script to the format of the new slippage query (or we remove that query and use a local database).