### PR TITLE
Update CoW AMM service fee bounty query to include all chains

### DIFF
--- a/cowamm/.sqlfluff
+++ b/cowamm/.sqlfluff
@@ -7,4 +7,4 @@ blockchain=ethereum
 start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
 results=final_results_per_solver,cow_surplus_per_batch
-budget=30000
+cow_budget=30000

--- a/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
+++ b/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
@@ -1,6 +1,6 @@
 -- This query computes how much surplus has been provided to CoW AMMs, when trading with other user orders
 -- as part of a CoW. For that, a CoW detector query is used (4025739(). Finally, the query computes the 
--- distribution of an amount {{budget}} of COW tokens to solvers, proportionally to the surplus generated 
+-- distribution of an amount {{cow_budget}} of COW tokens to solvers, proportionally to the surplus generated 
 -- via CoWs and pushed to CoW AMMs.
 -- Parameters:
 --  {{start_time}} - the start date timestamp for the accounting period  (inclusively)

--- a/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
+++ b/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
@@ -5,8 +5,7 @@
 -- Parameters:
 --  {{start_time}} - the start date timestamp for the accounting period  (inclusively)
 --  {{end_time}} - the end date timestamp for the accounting period (exclusively)
--- {{blockchain}} -- the chain we are interested in
--- {{budget}} -- the amount of COW that needs to be distributed
+-- {{cow_budget}} -- the amount of COW that needs to be distributed
 
 with cow_amm_surplus as (
     select
@@ -19,7 +18,7 @@ with cow_amm_surplus as (
     where istrade
 ),
 
-cow_surplus_per_batch as (
+cow_surplus_per_batch_ethereum as (
     select
         cow_per_batch.block_time,
         cow_per_batch.tx_hash,
@@ -27,30 +26,84 @@ cow_surplus_per_batch as (
         naive_cow,  -- fraction of batch volume traded within a CoW
         surplus as surplus_in_usd,  -- surplus of the executed CoW AMM order, expressed in USD
         naive_cow * surplus as realized_cow_surplus_in_usd -- surplus of the CoW AMM that is assumed to be generated via a CoW.
-    from "query_4025739(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')" as cow_per_batch
+    from "query_4025739(blockchain='ethereum',start_time='{{start_time}}',end_time='{{end_time}}')" as cow_per_batch
     inner join cow_amm_surplus on cow_per_batch.tx_hash = cow_amm_surplus.tx_hash
-    inner join cow_protocol_{{blockchain}}.batches as b on cow_per_batch.tx_hash = b.tx_hash
+    inner join cow_protocol_ethereum.batches as b on cow_per_batch.tx_hash = b.tx_hash
 ),
 
-aggregate_results_per_solver as (
+cow_surplus_per_batch_gnosis as (
+    select
+        cow_per_batch.block_time,
+        cow_per_batch.tx_hash,
+        solver_address,
+        naive_cow,  -- fraction of batch volume traded within a CoW
+        surplus as surplus_in_usd,  -- surplus of the executed CoW AMM order, expressed in USD
+        naive_cow * surplus as realized_cow_surplus_in_usd -- surplus of the CoW AMM that is assumed to be generated via a CoW.
+    from "query_4025739(blockchain='gnosis',start_time='{{start_time}}',end_time='{{end_time}}')" as cow_per_batch
+    inner join cow_amm_surplus on cow_per_batch.tx_hash = cow_amm_surplus.tx_hash
+    inner join cow_protocol_gnosis.batches as b on cow_per_batch.tx_hash = b.tx_hash
+),
+
+aggregate_results_per_solver_ethereum as (
     select
         name as solver_name,
         sum(realized_cow_surplus_in_usd) as total_cow_surplus_in_usd
-    from cow_surplus_per_batch
-    inner join cow_protocol_{{blockchain}}.solvers as s on cow_surplus_per_batch.solver_address = s.address and s.active
+    from cow_surplus_per_batch_ethereum
+    inner join cow_protocol_ethereum.solvers as s on cow_surplus_per_batch_ethereum.solver_address = s.address and s.active
     group by name
 ),
 
-total_surplus as (
-    select sum(total_cow_surplus_in_usd) as total_surplus_in_usd from aggregate_results_per_solver
+aggregate_results_per_solver_gnosis as (
+    select
+        name as solver_name,
+        sum(realized_cow_surplus_in_usd) as total_cow_surplus_in_usd
+    from cow_surplus_per_batch_gnosis
+    inner join cow_protocol_gnosis.solvers as s on cow_surplus_per_batch_gnosis.solver_address = s.address and s.active
+    group by name
 ),
 
-final_results_per_solver as (
+aggregate_results_per_solver_all_chains_temp as (
+    select *
+    from aggregate_results_per_solver_ethereum
+    union all
+    select *
+    from aggregate_results_per_solver_gnosis
+),
+
+aggregate_results_per_solver_all_chains as (
+    select
+        solver_name,
+        sum(total_cow_surplus_in_usd) as total_cow_surplus_in_usd
+    from
+        aggregate_results_per_solver_all_chains_temp
+    group by solver_name
+),
+
+total_surplus as (
+    select sum(total_cow_surplus_in_usd) as total_surplus_in_usd from aggregate_results_per_solver_all_chains
+),
+
+final_results_per_solver_prelim as (
     select
         arps.solver_name,
         total_cow_surplus_in_usd,
-        {{budget}} * arps.total_cow_surplus_in_usd / ts.total_surplus_in_usd as total_cow_reward
-    from aggregate_results_per_solver as arps cross join total_surplus as ts
+        {{cow_budget}} * arps.total_cow_surplus_in_usd / ts.total_surplus_in_usd as total_cow_reward
+    from aggregate_results_per_solver_all_chains as arps cross join total_surplus as ts
+),
+
+named_results as (
+    select
+        reward_target,
+        substring(solver_name, 6, 100) as solver_name
+    from "query_1541516(end_time='{{end_time}}',vouch_cte_name='named_results')"
+),
+
+final_results_per_solver as (
+    select distinct  --noqa: ST06
+        nr.reward_target,
+        frpsp.*
+    from final_results_per_solver_prelim as frpsp inner join named_results as nr on frpsp.solver_name = nr.solver_name
+    where frpsp.total_cow_reward > 0
 )
 
 select * from {{results}}


### PR DESCRIPTION
This PR updates query 4031724 so that it aggregates surplus over all chains, which is generated from CoWs between CoW AMMs and user orders. The [query](https://dune.com/queries/4031724) on Dune is already updated as we needed to use it to payout this week's bounty. Still a proper review would be ideal.

