### PR TITLE
Fix typo in unusual slippage query

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
@@ -14,7 +14,7 @@ select  --noqa: ST06
     rpt.block_time,
     concat(environment, '-', name) as solver_name,
     concat(
-        '<a href="https://dune.com/queries/4070065',
+        '<a href="https://dune.com/queries/4059683',
         '?blockchain=ethereum',
         '&start_time={{start_time}}',
         '&end_time={{end_time}}',

--- a/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
@@ -15,7 +15,7 @@ select  --noqa: ST06
     concat(environment, '-', name) as solver_name,
     concat(
         '<a href="https://dune.com/queries/4070065',
-        '&blockchain=ethereum',
+        '?blockchain=ethereum',
         '&start_time={{start_time}}',
         '&end_time={{end_time}}',
         '&slippage_table_name=raw_slippage_breakdown',


### PR DESCRIPTION
This PR fixes a typo in the unusual slippage query.

Due to the type, the link lead to a query with default paramters instead of the parameters from the url.