### PR TITLE
Add solver approvals query

### DIFF
--- a/cowprotocol/monitoring/.sqlfluff
+++ b/cowprotocol/monitoring/.sqlfluff
@@ -1,0 +1,3 @@
+[sqlfluff:templater:jinja:context]
+blockchain='ethereum'
+

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -17,7 +17,10 @@ select --noqa: ST06
     block_time,
     tx_hash,
     responsible_address,
-    coalesce(concat(environment, '-', name), 'NON-SOLVER') as responsible_solver,
+    case
+        when responsible_address = 0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382 then 'PROPOSER-ACCOUNT'
+        else coalesce(concat(environment, '-', name), 'NON-SOLVER')
+    end as responsible_solver,
     spender,
     token,
     value

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -8,8 +8,8 @@ ranked as (
         contract_address as token,
         a.value,
         rank() over (partition by spender, contract_address order by evt_block_number desc, evt_index desc) as rk
-    from erc20_ethereum.evt_Approval as a
-    inner join ethereum.transactions on evt_tx_hash = hash
+    from erc20_{{blockchain}}.evt_Approval as a
+    inner join {{blockchain}}.transactions on evt_tx_hash = hash
     where owner = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
 )
 
@@ -25,6 +25,6 @@ select --noqa: ST06
     token,
     value
 from ranked as r
-left outer join cow_protocol_ethereum.solvers as s on r.responsible_address = s.address
+left outer join cow_protocol_{{blockchain}}.solvers as s on r.responsible_address = s.address
 where rk = 1 and value > 0
 order by block_time desc

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -3,7 +3,7 @@ ranked as (
     select
         evt_tx_hash as tx_hash,
         evt_block_time as block_time,
-        "from" as tx_sender,
+        "from" as responsible_address,
         spender,
         contract_address as token,
         a.value,
@@ -16,12 +16,12 @@ ranked as (
 select --noqa: ST06
     block_time,
     tx_hash,
-    tx_sender as responsible_address,
+    responsible_address,
     coalesce(concat(environment, '-', name), 'NON-SOLVER') as responsible_solver,
     spender,
     token,
     value
 from ranked as r
-left outer join cow_protocol_ethereum.solvers as s on r.tx_sender = s.address
-where rk = 1 and value > 0
+left outer join cow_protocol_ethereum.solvers as s on r.responsible_address = s.address
+where rk = 1 and value > 0 and responsible_address != 0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382 -- exclude proposer account
 order by block_time desc

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -18,7 +18,7 @@ select --noqa: ST06
     tx_hash,
     responsible_address,
     case
-        when responsible_address = 0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382 then 'PROPOSER-ACCOUNT'
+        when responsible_address = 0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382 or responsible_address = 0xd8ca5fe380b68171155c7069b8df166db28befdd then 'PROPOSER-ACCOUNT'
         else coalesce(concat(environment, '-', name), 'NON-SOLVER')
     end as responsible_solver,
     spender,

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -1,0 +1,25 @@
+with
+ranked as (
+    select
+        evt_tx_hash as tx_hash,
+        evt_block_time as block_time,
+        "from" as tx_sender,
+        spender,
+        contract_address as token,
+        a.value,
+        rank() over (partition by spender, contract_address order by evt_block_number desc, evt_index desc) as rk
+    from erc20_ethereum.evt_Approval as a
+    left outer join ethereum.transactions on evt_tx_hash = hash and "to" = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+    where owner = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+)
+
+select --noqa: ST06
+    tx_hash,
+    block_time,
+    coalesce(cast(tx_sender as varchar), 'NON-SOLVER') as responsible_solver,
+    spender,
+    token,
+    value
+from ranked
+where rk = 1 and value > 0
+order by block_time desc

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -26,5 +26,5 @@ select --noqa: ST06
     value
 from ranked as r
 left outer join cow_protocol_ethereum.solvers as s on r.responsible_address = s.address
-where rk = 1 and value > 0 and responsible_address != 0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382 -- exclude proposer account
+where rk = 1 and value > 0
 order by block_time desc


### PR DESCRIPTION
This PR migrates the old solver approvals query -> https://dune.com/queries/1973291
that is not functioning anymore into a new query that is also slightly improved -> https://dune.com/queries/4173928

The main improvements are:

1.  The query now also checks for approvals not set by solvers by using a placeholder NON-SOLVER string instead of address; in such a case, the name of the responsible address is set to "NON-SOLVER".
2. It works for Gnosis Chain and Arbitrum as well

An improvement that could be done is to pull out the hardcoded proposer accounts from the query and have those as a separate "whitelisted addresses" query, that we can invoke from within the query of this PR.