### PR TITLE
Update bonding pools

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
@@ -16,6 +16,16 @@ full_bonding_pools as (
         from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address,
         'Project Blanc' as pool_name,
         from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as initial_funder
+    union distinct
+    select
+        from_hex('0x0deb0ae9c4399c51289adb1f3ed83557a56df657') as pool_address,
+        'Rizzolver' as pool_name,
+        from_hex('0x607DBe787C242e20A4897680357336E37954b3F0') as initial_funder
+    union distinct
+    select
+        from_hex('0x3075F6aab29D92F8F062A83A0318c52c16E69a60') as pool_address,
+        'Furucombo' as pool_name,
+        from_hex('0x539B3640c26D9159c9Ea9B7e2a1aa69D89Db6ee1') as initial_funder
 )
 
 select *


### PR DESCRIPTION
This PR updates the hardcoded bonding pools to include Rizzolver and Furucombo/Portus. The pools can be found on the CMS under solver-bonding pools