### PR TITLE
Fix CoW AMM CoW surplus query

### DIFF
--- a/cowamm/.sqlfluff
+++ b/cowamm/.sqlfluff
@@ -7,4 +7,4 @@ blockchain=ethereum
 start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
 results=final_results_per_solver,cow_surplus_per_batch
-budget=30000
+cow_budget=30000

--- a/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
+++ b/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
@@ -91,6 +91,7 @@ final_results_per_solver as (
         {{cow_budget}} * a.total_cow_surplus_in_usd / (select sum(total_cow_surplus_in_usd) from aggregate_result_per_solver) as total_cow_reward
     from aggregate_result_per_solver as a
     inner join reward_addresses as b on a.solver_name = b.solver_name
+    where a.total_cow_surplus_in_usd > 0
 )
 
-select * from {{results}} where total_cow_reward > 0
+select * from {{results}}

--- a/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
+++ b/cowamm/cow_amm_cow_with_users_surplus_query_4031724.sql
@@ -1,56 +1,78 @@
 -- This query computes how much surplus has been provided to CoW AMMs, when trading with other user orders
 -- as part of a CoW. For that, a CoW detector query is used (4025739(). Finally, the query computes the 
--- distribution of an amount {{budget}} of COW tokens to solvers, proportionally to the surplus generated 
+-- distribution of an amount {{cow_budget}} of COW tokens to solvers, proportionally to the surplus generated
 -- via CoWs and pushed to CoW AMMs.
 -- Parameters:
 --  {{start_time}} - the start date timestamp for the accounting period  (inclusively)
 --  {{end_time}} - the end date timestamp for the accounting period (exclusively)
--- {{blockchain}} -- the chain we are interested in
--- {{budget}} -- the amount of COW that needs to be distributed
+-- {{cow_budget}} -- the amount of COW that needs to be distributed
 
-with cow_amm_surplus as (
+with cow_surplus_per_batch_ethereum as (
     select
-        tx_hash,
-        case
-            when token_1_transfer_usd > 0 then token_1_transfer_usd + (token_1_balance_usd - token_1_transfer_usd) * token_2_transfer_usd / token_2_balance_usd
-            else token_2_transfer_usd + (token_2_balance_usd - token_2_transfer_usd) * token_1_transfer_usd / token_1_balance_usd
-        end as surplus
-    from dune.cowprotocol.result_balancer_cow_amm_base_query_v_2
-    where istrade
+        'ethereum' as blockchain,
+        cow_per_batch.block_time,
+        cow_per_batch.tx_hash,
+        solvers.name as solver_name,
+        naive_cow,  -- fraction of batch volume traded within a CoW
+        trades.surplus_usd as surplus_in_usd,  -- surplus of the executed CoW AMM order, expressed in USD
+        naive_cow * trades.surplus_usd as realized_cow_surplus_in_usd -- surplus of the CoW AMM that is assumed to be generated via a CoW.
+    from "query_4025739(blockchain='ethereum',start_time='{{start_time}}',end_time='{{end_time}}')" as cow_per_batch
+    inner join cow_protocol_ethereum.trades as trades on cow_per_batch.tx_hash = trades.tx_hash
+    inner join cow_protocol_ethereum.batches as batches on cow_per_batch.tx_hash = batches.tx_hash
+    inner join cow_protocol_ethereum.solvers as solvers on batches.solver_address = solvers.address and solvers.active
+    where trades.trader in (select address from query_3959044 where blockchain = 'ethereum')
+),
+
+cow_surplus_per_batch_gnosis as (
+    select
+        'gnosis' as blockchain,
+        cow_per_batch.block_time,
+        cow_per_batch.tx_hash,
+        solvers.name as solver_name,
+        naive_cow,  -- fraction of batch volume traded within a CoW
+        trades.surplus_usd as surplus_in_usd,  -- surplus of the executed CoW AMM order, expressed in USD
+        naive_cow * trades.surplus_usd as realized_cow_surplus_in_usd -- surplus of the CoW AMM that is assumed to be generated via a CoW.
+    from "query_4025739(blockchain='gnosis',start_time='{{start_time}}',end_time='{{end_time}}')" as cow_per_batch
+    inner join cow_protocol_gnosis.trades as trades on cow_per_batch.tx_hash = trades.tx_hash
+    inner join cow_protocol_gnosis.batches as batches on cow_per_batch.tx_hash = batches.tx_hash
+    inner join cow_protocol_gnosis.solvers as solvers on batches.solver_address = solvers.address and solvers.active
+    where trades.trader in (select address from query_3959044 where blockchain = 'gnosis')
 ),
 
 cow_surplus_per_batch as (
-    select
-        cow_per_batch.block_time,
-        cow_per_batch.tx_hash,
-        solver_address,
-        naive_cow,  -- fraction of batch volume traded within a CoW
-        surplus as surplus_in_usd,  -- surplus of the executed CoW AMM order, expressed in USD
-        naive_cow * surplus as realized_cow_surplus_in_usd -- surplus of the CoW AMM that is assumed to be generated via a CoW.
-    from "query_4025739(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')" as cow_per_batch
-    inner join cow_amm_surplus on cow_per_batch.tx_hash = cow_amm_surplus.tx_hash
-    inner join cow_protocol_{{blockchain}}.batches as b on cow_per_batch.tx_hash = b.tx_hash
+    select * from cow_surplus_per_batch_ethereum
+    union all
+    select * from cow_surplus_per_batch_gnosis
 ),
 
-aggregate_results_per_solver as (
+
+aggregate_result_per_solver as (
     select
-        name as solver_name,
+        solver_name,
         sum(realized_cow_surplus_in_usd) as total_cow_surplus_in_usd
     from cow_surplus_per_batch
-    inner join cow_protocol_{{blockchain}}.solvers as s on cow_surplus_per_batch.solver_address = s.address and s.active
-    group by name
+    group by solver_name
 ),
 
-total_surplus as (
-    select sum(total_cow_surplus_in_usd) as total_surplus_in_usd from aggregate_results_per_solver
+
+---- final results
+
+reward_addresses as (
+    select
+        solver as solver_address,
+        reward_target,
+        substring(solver_name, 6, 100) as solver_name
+    from "query_1541516(end_time='{{end_time}}',vouch_cte_name='named_results')"
 ),
 
 final_results_per_solver as (
-    select
-        arps.solver_name,
-        total_cow_surplus_in_usd,
-        {{budget}} * arps.total_cow_surplus_in_usd / ts.total_surplus_in_usd as total_cow_reward
-    from aggregate_results_per_solver as arps cross join total_surplus as ts
+    select distinct
+        a.solver_name,
+        b.reward_target,
+        a.total_cow_surplus_in_usd,
+        {{cow_budget}} * a.total_cow_surplus_in_usd / (select sum(total_cow_surplus_in_usd) from aggregate_result_per_solver) as total_cow_reward
+    from aggregate_result_per_solver as a
+    inner join reward_addresses as b on a.solver_name = b.solver_name
 )
 
-select * from {{results}}
+select * from {{results}} where total_cow_reward > 0


### PR DESCRIPTION
This PR updates the query for computing CoW surplus of CoW AMMs for the onboing bounty.

The old query was broken due to 80/20-pools since it used a formula for surplus which worked directly with reserves and product invariant ("non-linear surplus"). The resulted in the potential of negative surplus, messing up bounty rewards:

![image](https://github.com/user-attachments/assets/1de6a647-f2c9-4783-86ff-b04532eb8e00)

The new query uses surplus as defined in the competition ("linear suplus"). This generalizes to all kinds of CoW AMMs. It also reduces the dependency on a large table which indexes reserves of all CoW AMMs. The results with the updated query ([test query](https://dune.com/queries/4243577?end_time_d83555=2024-11-05+00%3A00%3A00&start_time_d83555=2024-10-29+00%3A00%3A00)) change to this:

![image](https://github.com/user-attachments/assets/3bf3177a-5f54-41a3-ba9b-02d11b486ecf)

One change in behavior is that we now do not reward solvers in cases where the limit price set by the solver does not lie on the curve. This is, however, in line with how we treat rewards in general and should not have a major impact.