### PR TITLE
Comptetitor AMMs KPIs

### DIFF
--- a/cowamm/.sqlfluff
+++ b/cowamm/.sqlfluff
@@ -8,3 +8,4 @@ start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
 results=final_results_per_solver,cow_surplus_per_batch
 cow_budget=30000
+number_of_pools=500

--- a/cowamm/profitability/competitor_kpis/curve/curve_kpis_4232873.sql
+++ b/cowamm/profitability/competitor_kpis/curve/curve_kpis_4232873.sql
@@ -1,0 +1,25 @@
+-- Computes volume, tvl and APR for Curve pools
+-- APR is measured as the fees earned per $ invested, over the last 24 hours, projected over 1 year
+-- Input: blockchain
+select r.contract_address,
+sum(amount_usd) as volume,
+365*greatest(0,sum(amount_usd*fee/tvl)) as apr,
+avg(fee) as fee,
+avg(tvl) as tvl
+from "query_4232976(blockchain='{{blockchain}}')" r
+left join curve.trades t 
+on r.contract_address = t.project_contract_address
+and r.tx_hash = t.tx_hash
+where t.block_time>=date_add('day', -1, now())
+group by r.contract_address
+
+union
+select 
+    contract_address, 
+    0 as volume, 
+    0 as apr,
+    fee,
+    tvl
+from "query_4232976(blockchain='{{blockchain}}')"
+where time<date_add('day', -1, now())
+and latest = 1

--- a/cowamm/profitability/competitor_kpis/curve/curve_kpis_4232873.sql
+++ b/cowamm/profitability/competitor_kpis/curve/curve_kpis_4232873.sql
@@ -3,7 +3,7 @@
 -- Input: blockchain
 select r.contract_address,
 sum(amount_usd) as volume,
-365*greatest(0,sum(amount_usd*fee/tvl)) as apr,
+365*sum(amount_usd*fee/tvl) as apr,
 avg(fee) as fee,
 avg(tvl) as tvl
 from "query_4232976(blockchain='{{blockchain}}')" r
@@ -11,6 +11,8 @@ left join curve.trades t
 on r.contract_address = t.project_contract_address
 and r.tx_hash = t.tx_hash
 where t.block_time>=date_add('day', -1, now())
+-- This test avoids any possible issue with reconstructing the reserves of the pool
+and tvl >0
 group by r.contract_address
 
 union

--- a/cowamm/profitability/competitor_kpis/curve/curve_largest_2token_pools_4232976.sql
+++ b/cowamm/profitability/competitor_kpis/curve/curve_largest_2token_pools_4232976.sql
@@ -1,0 +1,66 @@
+-- Finds all the curve pools with 2 tokens and their TVLs
+-- Input: blockchain
+
+with 
+-- filters pools with 2 tokens
+pools as(
+select pool_address as contract_address,
+coin0 as token0,
+coin1 as token1,
+mid_fee*power(10,-10) as fee
+from curvefi_{{blockchain}}.view_pools
+where coin2 = 0x0000000000000000000000000000000000000000),
+
+-- finds all transfers in and out of the pools to rebuild the reserves
+transfers as(
+select p.contract_address, token0, token1, -value as transfer0, 0 as transfer1, evt_index, evt_tx_hash as tx_hash, evt_block_time as time, fee
+    from pools p
+    join erc20_{{blockchain}}.evt_transfer t0
+    on p.contract_address = t0."from"
+    and p.token0 = t0.contract_address
+union
+select p.contract_address, token0, token1, value as transfer0, 0 as transfer1, evt_index, evt_tx_hash as tx_hash, evt_block_time as time, fee
+    from pools p
+    join erc20_{{blockchain}}.evt_transfer t0
+    on p.contract_address = t0.to
+    and p.token0 = t0.contract_address
+union
+select p.contract_address, token0, token1, 0 as transfer0, -value as transfer1, evt_index, evt_tx_hash as tx_hash, evt_block_time as time, fee
+    from pools p
+    join erc20_{{blockchain}}.evt_transfer t1
+    on p.contract_address = t1."from"
+    and p.token1 = t1.contract_address
+union
+select p.contract_address, token0, token1, 0 as transfer0, value as transfer1, evt_index, evt_tx_hash as tx_hash, evt_block_time as time, fee
+    from pools p
+    join erc20_{{blockchain}}.evt_transfer t1
+    on p.contract_address = t1.to
+    and p.token1 = t1.contract_address),
+
+-- rebuilds the reserves from the transfers
+-- ETH transfers are not considered  
+reserves as(
+select contract_address, token0, token1, tx_hash, time,
+sum(transfer0) over (partition by contract_address order by time, evt_index) as reserve0,
+sum(transfer1) over (partition by contract_address order by time, evt_index) as reserve1,
+fee,
+ROW_NUMBER() OVER (PARTITION BY tx_hash,contract_address ORDER BY evt_index DESC) AS row_num,
+ROW_NUMBER() OVER (PARTITION BY contract_address ORDER BY time DESC) AS latest
+from transfers)
+
+-- finds the TVL of the pools
+select r.contract_address, token0, token1, time, tx_hash,
+reserve0, reserve1,
+(reserve0 * p0.price / pow(10, p0.decimals)) + (reserve1 * p1.price / pow(10, p1.decimals)) as tvl,
+fee, latest
+from reserves r
+inner join prices.usd as p0
+        on
+            date_trunc('minute', time) = p0.minute
+            and token0 = p0.contract_address
+    inner join prices.usd as p1
+        on
+            date_trunc('minute', time) = p1.minute
+            and token1 = p1.contract_address 
+where row_num = 1
+

--- a/cowamm/profitability/competitor_kpis/pancakeswap/pancakeswap_kpis_4232738.sql
+++ b/cowamm/profitability/competitor_kpis/pancakeswap/pancakeswap_kpis_4232738.sql
@@ -1,0 +1,79 @@
+-- Computes volume, tvl and APR for Pancakeswap pools
+-- APR is measured as the fees earned per $ invested, over the last 24 hours, projected over 1 year
+-- Input: blockchain
+
+with 
+-- select the pool with the largest latest k
+pool as (
+    select
+        contract_address,
+        token0,
+        token1
+    from "query_4232660(blockchain='{{blockchain}}')"
+    where latest = 1
+),
+
+swaps as (
+    select
+        tx_hash as evt_tx_hash,
+        index as evt_index,
+        block_time as evt_block_time,
+        block_number as evt_block_number,
+        contract_address,
+        varbinary_to_uint256(substr(data, 1, 32)) as amount0In,
+        varbinary_to_uint256(substr(data, 33, 32)) as amount1In,
+        varbinary_to_uint256(substr(data, 65, 32)) as amount0Out,
+        varbinary_to_uint256(substr(data, 97, 32)) as amount1Out
+    from {{blockchain}}.logs
+    where
+        topic0 = 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822 -- Swap
+        and contract_address in (select contract_address from pool)
+),
+
+-- gets the swapped volume and tvl at the time of the swap for each swap
+tvl_volume_per_swap as (
+    select
+        syncs.contract_address as contract_address,
+        syncs.evt_block_time,
+        syncs.evt_tx_hash,
+        (amount0In * p0.price / pow(10, p0.decimals)) + (amount1In * p1.price / pow(10, p1.decimals)) as volume_in,
+        (amount0Out * p0.price / pow(10, p0.decimals)) + (amount1Out * p1.price / pow(10, p1.decimals)) as volume_out,
+        (reserve0 * p0.price / pow(10, p0.decimals)) + (reserve1 * p1.price / pow(10, p1.decimals)) as tvl
+    from "query_4232660(blockchain='{{blockchain}}')" as syncs
+    inner join swaps
+        on
+            syncs.evt_tx_hash = swaps.evt_tx_hash
+            and syncs.contract_address = swaps.contract_address
+            and syncs.evt_index + 1 = swaps.evt_index
+    inner join pool
+        on syncs.contract_address = pool.contract_address
+    inner join prices.usd as p0
+        on
+            date_trunc('minute', syncs.evt_block_time) = p0.minute
+            and syncs.token0 = p0.contract_address
+    inner join prices.usd as p1
+        on
+            date_trunc('minute', syncs.evt_block_time) = p1.minute
+            and syncs.token1 = p1.contract_address
+    where syncs.evt_block_time >= date(date_add('day', -7, now()))
+)
+
+select
+    contract_address,
+    sum((volume_in + volume_out) / 2) as volume,
+    avg(tvl) as tvl,
+    365*sum((volume_in + volume_out) / 2 / tvl) * 0.003 as apr,
+    0.003 as fee
+from tvl_volume_per_swap
+    where evt_block_time >= date_add('day', -1, now())
+group by contract_address
+
+union
+select 
+    pool_address as contract_address, 
+    0 as volume, 
+    tvl,
+    0 as apr,
+    0.003 as fee
+from "query_4232597(blockchain='{{blockchain}}')"
+where pool_address not in (select contract_address from tvl_volume_per_swap)

--- a/cowamm/profitability/competitor_kpis/pancakeswap/pancakeswap_largest_pools_4232597.sql
+++ b/cowamm/profitability/competitor_kpis/pancakeswap/pancakeswap_largest_pools_4232597.sql
@@ -1,0 +1,49 @@
+-- Computes the TVL for every Pancakeswap pool
+-- Then returns the top {{number_of_pools}} pools by TVL
+-- Input: blockchain, number_of_pools to return
+
+with 
+-- finds the pools which have been active since 2024-10-01
+data as (
+select 
+    p.contract_address as pool_address,
+    call_block_time as time,
+    output__reserve0 as balance0,
+    output__reserve1 as balance1,
+    rank() over (partition by p.contract_address order by p.call_block_time desc) latest
+from pancakeswap_v2_{{blockchain}}.PancakePair_call_getReserves p 
+where date_trunc('day',call_block_time) >= date_trunc('day', cast('2024-10-01' as date))),
+
+--Gets the token0 and token1 addresses for each pool
+t0 as (select contract_address, max(output_0) as token0 
+    from pancakeswap_v2_{{blockchain}}.PancakePair_call_token0
+    group by contract_address),
+    
+t1 as (select contract_address, max(output_0) as token1
+    from pancakeswap_v2_{{blockchain}}.PancakePair_call_token1
+    group by contract_address),
+
+--computes the tvl for each pool
+-- for each pool we could get multiple balance values if the function was called multiple times in a same block
+-- we arbitrarily choose the maximum value for each pool
+recent_tvl as(
+select pool_address,
+token0, max(balance0) as balance0,
+token1, max(balance1) as balance1,
+max(least(balance0,balance1)* greatest(p0.price/pow(10, p0.decimals),p1.price/pow(10, p1.decimals)) +
+ greatest(balance0,balance1)* least(p0.price/pow(10, p0.decimals),p1.price/pow(10, p1.decimals))) as tvl
+from data
+join t0
+    on pool_address = t0.contract_address
+join t1
+    on pool_address = t1.contract_address
+join prices.usd_latest as p0
+    on token0 = p0.contract_address
+join prices.usd_latest as p1
+    on token1 = p1.contract_address
+where latest = 1
+group by 1,2,4)
+
+select * from recent_tvl
+order by tvl desc
+limit {{number_of_pools}}

--- a/cowamm/profitability/competitor_kpis/pancakeswap/pancakeswap_syncs_4232660.sql
+++ b/cowamm/profitability/competitor_kpis/pancakeswap/pancakeswap_syncs_4232660.sql
@@ -1,0 +1,27 @@
+-- Finds the pancakeswap v2 pool address given tokens specified in query parameters (regardless of order)
+with pools as (
+    select
+        substr(data, 13, 20) as contract_address,
+        substr(topic1, 13, 20) as token0,
+        substr(topic2, 13, 20) as token1
+    from {{blockchain}}.logs
+    where
+        topic0 = 0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9 -- PairCreated
+        -- topic1: 0x0...0<token0>, topic2: 0x0...0<token1>
+        and substr(data, 13, 20) in (select pool_address from "query_4232597(blockchain='{{blockchain}}')")
+)
+
+select
+    pools.*,
+    tx_hash as evt_tx_hash,
+    index as evt_index,
+    block_time as evt_block_time,
+    block_number as evt_block_number,
+    varbinary_to_uint256(substr(data, 1, 32)) as reserve0,
+    varbinary_to_uint256(substr(data, 33, 32)) as reserve1,
+    rank() over (partition by (logs.contract_address) order by block_time desc) as latest
+from {{blockchain}}.logs
+inner join pools
+    on logs.contract_address = pools.contract_address
+where
+    topic0 = 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1 -- Sync

--- a/cowamm/profitability/competitor_kpis/sushiswap/sushiswap_kpis_4232588.sql
+++ b/cowamm/profitability/competitor_kpis/sushiswap/sushiswap_kpis_4232588.sql
@@ -1,0 +1,79 @@
+-- Computes volume, tvl and APR for Sushiswap pools
+-- APR is measured as the fees earned per $ invested, over the last 24 hours, projected over 1 year
+-- Input: blockchain
+
+with 
+-- select the pool with the largest latest k
+pool as (
+    select
+        contract_address,
+        token0,
+        token1
+    from "query_4227247(blockchain='{{blockchain}}')"
+    where latest = 1
+),
+
+swaps as (
+    select
+        tx_hash as evt_tx_hash,
+        index as evt_index,
+        block_time as evt_block_time,
+        block_number as evt_block_number,
+        contract_address,
+        varbinary_to_uint256(substr(data, 1, 32)) as amount0In,
+        varbinary_to_uint256(substr(data, 33, 32)) as amount1In,
+        varbinary_to_uint256(substr(data, 65, 32)) as amount0Out,
+        varbinary_to_uint256(substr(data, 97, 32)) as amount1Out
+    from {{blockchain}}.logs
+    where
+        topic0 = 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822 -- Swap
+        and contract_address in (select contract_address from pool)
+),
+
+-- gets the swapped volume and tvl at the time of the swap for each swap
+tvl_volume_per_swap as (
+    select
+        syncs.contract_address as contract_address,
+        syncs.evt_block_time,
+        syncs.evt_tx_hash,
+        (amount0In * p0.price / pow(10, p0.decimals)) + (amount1In * p1.price / pow(10, p1.decimals)) as volume_in,
+        (amount0Out * p0.price / pow(10, p0.decimals)) + (amount1Out * p1.price / pow(10, p1.decimals)) as volume_out,
+        (reserve0 * p0.price / pow(10, p0.decimals)) + (reserve1 * p1.price / pow(10, p1.decimals)) as tvl
+    from "query_4227247(blockchain='{{blockchain}}')" as syncs
+    inner join swaps
+        on
+            syncs.evt_tx_hash = swaps.evt_tx_hash
+            and syncs.contract_address = swaps.contract_address
+            and syncs.evt_index + 1 = swaps.evt_index
+    inner join pool
+        on syncs.contract_address = pool.contract_address
+    inner join prices.usd as p0
+        on
+            date_trunc('minute', syncs.evt_block_time) = p0.minute
+            and syncs.token0 = p0.contract_address
+    inner join prices.usd as p1
+        on
+            date_trunc('minute', syncs.evt_block_time) = p1.minute
+            and syncs.token1 = p1.contract_address
+    where syncs.evt_block_time >= date(date_add('day', -7, now()))
+)
+
+select
+    contract_address,
+    sum((volume_in + volume_out) / 2) as volume,
+    avg(tvl) as tvl,
+    365*sum((volume_in + volume_out) / 2 / tvl) * 0.003 as apr,
+    0.003 as fee
+from tvl_volume_per_swap
+    where evt_block_time >= date_add('day', -1, now())
+group by contract_address
+
+union
+select 
+    pool_address as contract_address, 
+    0 as volume, 
+    tvl,
+    0 as apr,
+    0.003 as fee
+from "query_4223554(blockchain='{{blockchain}}')"
+where pool_address not in (select contract_address from tvl_volume_per_swap)

--- a/cowamm/profitability/competitor_kpis/sushiswap/sushiswap_largest_pools_4223554.sql
+++ b/cowamm/profitability/competitor_kpis/sushiswap/sushiswap_largest_pools_4223554.sql
@@ -1,0 +1,48 @@
+-- Computes the TVL for every Sushiswap pool
+-- Then returns the top {{number_of_pools}} pools by TVL
+-- Input: blockchain, number_of_pools to return
+
+with 
+-- finds the pools which have been active since 2024-10-01
+data as (
+select 
+    p.contract_address as pool_address,
+    call_block_time as time,
+    output__reserve0 as balance0,
+    output__reserve1 as balance1,
+    rank() over (partition by p.contract_address order by p.call_block_time desc) latest
+from sushi_{{blockchain}}.Pair_call_getReserves p 
+where date_trunc('day',call_block_time) >= date_trunc('day', cast('2024-10-01' as date))),
+
+--Gets the token0 and token1 addresses for each pool
+t0 as (select contract_address, max(output_0) as token0 
+    from sushi_{{blockchain}}.Pair_call_token0
+    group by contract_address),
+t1 as (select contract_address, max(output_0) as token1
+    from sushi_{{blockchain}}.Pair_call_token1
+    group by contract_address),
+
+--computes the tvl for each pool
+-- for each pool we could get multiple balance values if the function was called multiple times in a same block
+-- we arbitrarily choose the maximum value for each pool
+recent_tvl as(
+select pool_address,
+token0, max(balance0) as balance0,
+token1, max(balance1) as balance1,
+max(least(balance0,balance1)* greatest(p0.price/pow(10, p0.decimals),p1.price/pow(10, p1.decimals)) +
+ greatest(balance0,balance1)* least(p0.price/pow(10, p0.decimals),p1.price/pow(10, p1.decimals))) as tvl
+from data
+join t0
+    on pool_address = t0.contract_address
+join t1
+    on pool_address = t1.contract_address
+join prices.usd_latest as p0
+    on token0 = p0.contract_address
+join prices.usd_latest as p1
+    on token1 = p1.contract_address
+where latest = 1
+group by 1,2,4)
+
+select * from recent_tvl
+order by tvl desc
+limit {{number_of_pools}}

--- a/cowamm/profitability/competitor_kpis/sushiswap/sushiswap_syncs_4227247.sql
+++ b/cowamm/profitability/competitor_kpis/sushiswap/sushiswap_syncs_4227247.sql
@@ -1,0 +1,27 @@
+-- Finds the sushiswap v2 pool address given tokens specified in query parameters (regardless of order)
+with pools as (
+    select
+        substr(data, 13, 20) as contract_address,
+        substr(topic1, 13, 20) as token0,
+        substr(topic2, 13, 20) as token1
+    from {{blockchain}}.logs
+    where
+        topic0 = 0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9 -- PairCreated
+        -- topic1: 0x0...0<token0>, topic2: 0x0...0<token1>
+        and substr(data, 13, 20) in (select pool_address from query_4223554)
+)
+
+select
+    pools.*,
+    tx_hash as evt_tx_hash,
+    index as evt_index,
+    block_time as evt_block_time,
+    block_number as evt_block_number,
+    varbinary_to_uint256(substr(data, 1, 32)) as reserve0,
+    varbinary_to_uint256(substr(data, 33, 32)) as reserve1,
+    rank() over (partition by (logs.contract_address) order by block_time desc) as latest
+from {{blockchain}}.logs
+inner join pools
+    on logs.contract_address = pools.contract_address
+where
+    topic0 = 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1 -- Sync

--- a/cowamm/profitability/competitor_kpis/uniswap/uniswap_kpis_4229217.sql
+++ b/cowamm/profitability/competitor_kpis/uniswap/uniswap_kpis_4229217.sql
@@ -1,0 +1,79 @@
+-- Computes volume, tvl and APR for Uniswap pools
+-- APR is measured as the fees earned per $ invested, over the last 24 hours, projected over 1 year
+-- Input: blockchain
+
+with 
+-- select the pool with the largest latest k
+pool as (
+    select
+        contract_address,
+        token0,
+        token1
+    from "query_4227456(blockchain='{{blockchain}}')"
+    where latest = 1
+),
+
+swaps as (
+    select
+        tx_hash as evt_tx_hash,
+        index as evt_index,
+        block_time as evt_block_time,
+        block_number as evt_block_number,
+        contract_address,
+        varbinary_to_uint256(substr(data, 1, 32)) as amount0In,
+        varbinary_to_uint256(substr(data, 33, 32)) as amount1In,
+        varbinary_to_uint256(substr(data, 65, 32)) as amount0Out,
+        varbinary_to_uint256(substr(data, 97, 32)) as amount1Out
+    from {{blockchain}}.logs
+    where
+        topic0 = 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822 -- Swap
+        and contract_address in (select contract_address from pool)
+),
+
+-- gets the swapped volume and tvl at the time of the swap for each swap
+tvl_volume_per_swap as (
+    select
+        syncs.contract_address as contract_address,
+        syncs.evt_block_time,
+        syncs.evt_tx_hash,
+        (amount0In * p0.price / pow(10, p0.decimals)) + (amount1In * p1.price / pow(10, p1.decimals)) as volume_in,
+        (amount0Out * p0.price / pow(10, p0.decimals)) + (amount1Out * p1.price / pow(10, p1.decimals)) as volume_out,
+        (reserve0 * p0.price / pow(10, p0.decimals)) + (reserve1 * p1.price / pow(10, p1.decimals)) as tvl
+    from "query_4227456(blockchain='{{blockchain}}')" as syncs
+    inner join swaps
+        on
+            syncs.evt_tx_hash = swaps.evt_tx_hash
+            and syncs.contract_address = swaps.contract_address
+            and syncs.evt_index + 1 = swaps.evt_index
+    inner join pool
+        on syncs.contract_address = pool.contract_address
+    inner join prices.usd as p0
+        on
+            date_trunc('minute', syncs.evt_block_time) = p0.minute
+            and syncs.token0 = p0.contract_address
+    inner join prices.usd as p1
+        on
+            date_trunc('minute', syncs.evt_block_time) = p1.minute
+            and syncs.token1 = p1.contract_address
+    where syncs.evt_block_time >= date(date_add('day', -7, now()))
+)
+
+select
+    contract_address,
+    sum((volume_in + volume_out) / 2) as volume,
+    avg(tvl) as tvl,
+    365*sum((volume_in + volume_out) / 2 / tvl) * 0.003 as apr,
+    0.003 as fee
+from tvl_volume_per_swap
+    where evt_block_time >= date_add('day', -1, now())
+group by contract_address
+
+union
+select 
+    pool_address as contract_address, 
+    0 as volume, 
+    tvl,
+    0 as apr,
+    0.003 as fee
+from "query_4223063(blockchain='{{blockchain}}')"
+where pool_address not in (select contract_address from tvl_volume_per_swap)

--- a/cowamm/profitability/competitor_kpis/uniswap/uniswap_largest_pools_4223063.sql
+++ b/cowamm/profitability/competitor_kpis/uniswap/uniswap_largest_pools_4223063.sql
@@ -1,0 +1,48 @@
+-- Computes the TVL for every Uniswap pool
+-- Then returns the top {{number_of_pools}} pools by TVL
+-- Input: blockchain, number_of_pools to return
+
+with 
+-- finds the pools which have been active since 2024-10-01
+data as (
+select 
+    p.contract_address as pool_address,
+    call_block_time as time,
+    output__reserve0 as balance0,
+    output__reserve1 as balance1,
+    rank() over (partition by p.contract_address order by p.call_block_time desc) latest
+from uniswap_v2_{{blockchain}}.Pair_call_getReserves p 
+where date_trunc('day',call_block_time) >= date_trunc('day', cast('2024-10-01' as date))),
+
+--Gets the token0 and token1 addresses for each pool
+t0 as (select contract_address, max(output_0) as token0 
+    from uniswap_v2_{{blockchain}}.Pair_call_token0
+    group by contract_address),
+t1 as (select contract_address, max(output_0) as token1
+    from uniswap_v2_{{blockchain}}.Pair_call_token1 
+    group by contract_address),
+
+--computes the tvl for each pool
+-- for each pool we could get multiple balance values if the function was called multiple times in a same block
+-- we arbitrarily choose the maximum value for each pool
+recent_tvl as(
+select pool_address,
+token0, max(balance0) as balance0,
+token1, max(balance1) as balance1,
+max(least(balance0,balance1)* greatest(p0.price/pow(10, p0.decimals),p1.price/pow(10, p1.decimals)) +
+ greatest(balance0,balance1)* least(p0.price/pow(10, p0.decimals),p1.price/pow(10, p1.decimals))) as tvl
+from data
+join t0
+    on pool_address = t0.contract_address
+join t1
+    on pool_address = t1.contract_address
+join prices.usd_latest as p0
+    on token0 = p0.contract_address
+join prices.usd_latest as p1
+    on token1 = p1.contract_address
+where latest = 1
+group by 1,2,4)
+
+select * from recent_tvl
+order by tvl desc
+limit {{number_of_pools}}

--- a/cowamm/profitability/competitor_kpis/uniswap/uniswap_syncs_4227456.sql
+++ b/cowamm/profitability/competitor_kpis/uniswap/uniswap_syncs_4227456.sql
@@ -1,0 +1,27 @@
+-- Finds the uniswap v2 pool address given tokens specified in query parameters (regardless of order)
+with pools as (
+    select
+        substr(data, 13, 20) as contract_address,
+        substr(topic1, 13, 20) as token0,
+        substr(topic2, 13, 20) as token1
+    from {{blockchain}}.logs
+    where
+        topic0 = 0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9 -- PairCreated
+        -- topic1: 0x0...0<token0>, topic2: 0x0...0<token1>
+        and substr(data, 13, 20) in (select pool_address from query_4223063)
+)
+
+select
+    pools.*,
+    tx_hash as evt_tx_hash,
+    index as evt_index,
+    block_time as evt_block_time,
+    block_number as evt_block_number,
+    varbinary_to_uint256(substr(data, 1, 32)) as reserve0,
+    varbinary_to_uint256(substr(data, 33, 32)) as reserve1,
+    rank() over (partition by (logs.contract_address) order by block_time desc) as latest
+from {{blockchain}}.logs
+inner join pools
+    on logs.contract_address = pools.contract_address
+where
+    topic0 = 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1 -- Sync


### PR DESCRIPTION
This PR measures TVL, 24H Volume and 24H APR for 4 existing AMMs (Uniswap, Sushiswap, Pancakeswap and curve)
The 24H APR is defined as `sum(volume*feePct/TVL)*365` over the past 24H.

Uni, Sushi and Pancake are based on the same code. The queries are very similar to one another with only differences in the tables to look into.
For each, there is one first query which looks at the reserves of each pool, to find the largest ones. 
Then the query sync comes from previous code and kpis is a modified version of the 10k comparison to measure only the 24H APR.

For Curve, there are less tables available and information in the events. So, we calculate the reserves based on all transfers of the 2 tokens involved in the pools. 
The trades are dervived from a dedicated dune table.
There might be one issue with ETH transfer which seems to impact only one pool with appears to have a negative TVL.