### PR TITLE
Add raw price feed query

### DIFF
--- a/cowprotocol/accounting/price_feed/.sqlfluff
+++ b/cowprotocol/accounting/price_feed/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff:templater:jinja:context]
+blockchain='ethereum'

--- a/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
+++ b/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
@@ -1,0 +1,41 @@
+with imported_prices as (
+    select
+        token_address,
+        cast(replace(time, 'T', ' ') as timestamp) as time, --noqa: RF04
+        cast(price as double) as price_unit_eth,
+        decimals,
+        source
+    from dune.cowprotocol.dataset_price_feed_ethereum
+),
+
+processed_data as (
+    select -- noqa: ST06
+        token_address,
+        date_trunc('minute', time) as minute, --noqa: RF04
+        decimals,
+        source,
+        avg(price_unit_eth) as price_unit_eth
+    from imported_prices group by 1, 2, 3, 4
+),
+
+processed_data_with_usd_prices as (
+    select -- noqa: ST06
+        pd.token_address,
+        pd.minute,
+        pd.decimals,
+        pd.price_unit_eth,
+        pd.price_unit_eth * p.price as price_unit,
+        pd.price_unit_eth * p.price / pow(10, pd.decimals) as price_atom,
+        source
+    from processed_data as pd inner join prices.usd as p on pd.minute = p.minute
+    where p.contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 and blockchain = 'ethereum'
+)
+
+select -- noqa: ST06
+    token_address,
+    date_trunc('hour', minute) as hour, --noqa: RF04
+    decimals,
+    source,
+    avg(price_unit) as price_unit,
+    avg(price_atom) as price_atom
+from processed_data_with_usd_prices group by 1, 2, 3, 4

--- a/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
+++ b/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
@@ -8,7 +8,7 @@ with imported_prices as (
     from dune.cowprotocol.dataset_price_feed_ethereum
 ),
 
-processed_data as (
+imported_prices_per_minute as (
     select -- noqa: ST06
         token_address,
         date_trunc('minute', time) as minute, --noqa: RF04
@@ -18,16 +18,16 @@ processed_data as (
     from imported_prices group by 1, 2, 3, 4
 ),
 
-processed_data_with_usd_prices as (
+imported_prices_per_minute_with_usd_prices as (
     select -- noqa: ST06
-        pd.token_address,
-        pd.minute,
-        pd.decimals,
-        pd.price_unit_eth,
-        pd.price_unit_eth * p.price as price_unit,
-        pd.price_unit_eth * p.price / pow(10, pd.decimals) as price_atom,
+        ippm.token_address,
+        ippm.minute,
+        ippm.decimals,
+        ippm.price_unit_eth,
+        ippm.price_unit_eth * p.price as price_unit,
+        ippm.price_unit_eth * p.price / pow(10, ippm.decimals) as price_atom,
         source
-    from processed_data as pd inner join prices.usd as p on pd.minute = p.minute
+    from imported_prices_per_minute as ippm inner join prices.usd as p on ippm.minute = p.minute
     where p.contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 and blockchain = 'ethereum'
 )
 
@@ -38,4 +38,4 @@ select -- noqa: ST06
     source,
     avg(price_unit) as price_unit,
     avg(price_atom) as price_atom
-from processed_data_with_usd_prices group by 1, 2, 3, 4
+from imported_prices_per_minute_with_usd_prices group by 1, 2, 3, 4

--- a/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
+++ b/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
@@ -5,7 +5,7 @@ with imported_prices as (
         cast(price as double) as price_unit_eth,
         decimals,
         source
-    from dune.cowprotocol.dataset_price_feed_ethereum
+    from dune.cowprotocol.dataset_price_feed_{{blockchain}}
 ),
 
 imported_prices_per_minute as (

--- a/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
+++ b/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
@@ -1,3 +1,18 @@
+-- This query parses the raw price_feed table that we sync on Dune,
+-- and returns a view that is based on hourly prices, similar to
+-- how the Dune price feed is used for slippage accounting
+--
+-- Parameters:
+--  {{blockchain}} - network to run the analysis on; currently it only works for mainnet
+--
+-- The columns of the result are
+-- - token_address: a token
+-- - hour: the hour for which a price is computed
+-- - decimals: the decimals of the token
+-- - source: the source from which this price was computed,
+--   price_unit: the price, in USD, of one unit of the token
+-- - price_atom: the price, in USD, of one atom of the token
+
 with imported_prices as (
     select
         token_address,


### PR DESCRIPTION
This PR adds a view of the mainnet price feed that we currently upload, that is set up in such a way so that it can be used right away with the existing slippage calculations. This means that for every price feed, and each token, we compute an average price for each hour (as this is what we have also been doing with the Dune price feed).