### PR TITLE
Add multiple price feeds option

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
@@ -16,6 +16,7 @@ select  --noqa: ST06
     concat(
         '<a href="https://dune.com/queries/4059683',
         '?blockchain=ethereum',
+        '&price_feed=dune_price_feed'
         '&start_time={{start_time}}',
         '&end_time={{end_time}}',
         '&slippage_table_name=raw_slippage_breakdown',

--- a/cowprotocol/accounting/slippage/.sqlfluff
+++ b/cowprotocol/accounting/slippage/.sqlfluff
@@ -4,3 +4,4 @@ end_time='2024-08-02 12:00'
 blockchain='ethereum'
 slippage_table_name=slippage_per_solver,slippage_per_transaction
 raw_slippage_table_name=raw_slippage_breakdown,raw_slippage_per_transaction
+price_feed=dune_price_feed,multiple_price_feeds

--- a/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
+++ b/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
@@ -46,7 +46,7 @@ fees as (
         -amount as amount,
         fee_type as slippage_type,
         date_trunc('hour', block_time) as hour --noqa: RF04
-    from "query_4058574(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')"
+    from "query_4058574(blockchain='{{blockchain}}',price_feed='{{price_feed}}',start_time='{{start_time}}',end_time='{{end_time}}')"
 ),
 
 imbalances as (

--- a/cowprotocol/accounting/slippage/slippage_4070065.sql
+++ b/cowprotocol/accounting/slippage/slippage_4070065.sql
@@ -34,7 +34,7 @@ slippage_per_transaction as (
         solver_address,
         sum(slippage_usd) as slippage_usd,
         sum(slippage_wei) as slippage_wei
-    from "query_4059683(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}',raw_slippage_table_name='raw_slippage_breakdown')" as rs
+    from "query_4059683(blockchain='{{blockchain}}',price_feed='{{price_feed}}',start_time='{{start_time}}',end_time='{{end_time}}',raw_slippage_table_name='raw_slippage_breakdown')" as rs
     inner join cow_protocol_{{blockchain}}.batches as b
         on rs.tx_hash = b.tx_hash
     where rs.tx_hash not in (select tx_hash from excluded_batches)


### PR DESCRIPTION
This PR adds the option to use multiple price feeds as follows:
- at most 4 price feeds are considered, and the` approx_percentile(0.5)` is used to compute a price based on these price feeds.  This replaces what has been now only the dune price.

In case all price feeds return null, we continue to use the fallbacks that have been used up till now