### PR TITLE
Execution quality comparison

### DIFF
--- a/cowprotocol/execution_quality/.sqlfluff
+++ b/cowprotocol/execution_quality/.sqlfluff
@@ -4,5 +4,5 @@ project='cow_protocol'
 project_a='cow_protocol'
 project_b='cow_protocol'
 blockchain='ethereum'
-top_n_tokens=100
+top_n_pairs=100
 

--- a/cowprotocol/execution_quality/.sqlfluff
+++ b/cowprotocol/execution_quality/.sqlfluff
@@ -1,4 +1,8 @@
 [sqlfluff:templater:jinja:context]
 start='2024-08-20 00:00:00'
 project='cow_protocol'
+project_a='cow_protocol'
+project_b='cow_protocol'
 blockchain='ethereum'
+top_n_tokens=100
+

--- a/cowprotocol/execution_quality/.sqlflull
+++ b/cowprotocol/execution_quality/.sqlflull
@@ -1,0 +1,4 @@
+[sqlfluff:templater:jinja:context]
+start='2024-08-20 00:00:00'
+project='cow_protocol'
+blockchain='ethereum'

--- a/cowprotocol/execution_quality/aggregator_markout_4334277.sql
+++ b/cowprotocol/execution_quality/aggregator_markout_4334277.sql
@@ -6,33 +6,36 @@
 --  {{start}} - Start date for when trades should be counted
 --  {{blockchain}} - The chain on which trades should be counted
 
-with trades as(
-    select 
-        block_time, 
-        amount_usd, 
-        (token_bought_amount/token_sold_amount) as project_price,
-        p1.price/p0.price as dune_price,
-        token_bought_symbol, 
-        token_sold_symbol
-    from dex_aggregator.trades p
-    join prices.usd p0 
-        on p0.contract_address = token_bought_address 
-        and p0.minute = date_trunc('minute',p.block_time)
-    join prices.usd p1 
-        on p1.contract_address = token_sold_address 
-        and p1.minute = date_trunc('minute',p.block_time)
-    where block_time >= timestamp '{{start}}'
-    and token_sold_amount > 0
-    and p1.price > 0
-    and p.blockchain = '{{blockchain}}'
-    and project = '{{project}}'
+with trades as (
+    select
+        block_time,
+        amount_usd,
+        token_bought_symbol,
+        token_sold_symbol,
+        (token_bought_amount / token_sold_amount) as project_price,
+        p1.price / p0.price as dune_price
+    from dex_aggregator.trades as p
+    inner join prices.usd as p0
+        on
+            p0.contract_address = token_bought_address
+            and p0.minute = date_trunc('minute', p.block_time)
+    inner join prices.usd as p1
+        on
+            p1.contract_address = token_sold_address
+            and p1.minute = date_trunc('minute', p.block_time)
+    where
+        block_time >= timestamp '{{start}}'
+        and token_sold_amount > 0
+        and p1.price > 0
+        and p.blockchain = '{{blockchain}}'
+        and project = '{{project}}'
 )
 
-select 
-    token_bought_symbol as buy_token, 
+select
+    token_bought_symbol as buy_token,
     token_sold_symbol as sell_token,
     -- geometric volume-weighted price ratio
-    exp(sum(amount_usd*ln(project_price/dune_price))/sum(amount_usd)) as dune_price_ratio,
+    exp(sum(amount_usd * ln(project_price / dune_price)) / sum(amount_usd)) as dune_price_ratio,
     sum(amount_usd) as volume
 from trades
-group by 1,2
+group by 1, 2

--- a/cowprotocol/execution_quality/aggregator_markout_4334277.sql
+++ b/cowprotocol/execution_quality/aggregator_markout_4334277.sql
@@ -5,8 +5,20 @@
 --  {{project}} - The aggregator to look at
 --  {{start}} - Start date for when trades should be counted
 --  {{blockchain}} - The chain on which trades should be counted
+--  {{top_n_pairs}} - Based on total DEX trading volume how many of the top token pairs to consider
 
-with trades as (
+with token_pairs as (
+    select
+        token_pair,
+        sum(amount_usd) as volume
+    from dex_aggregator.trades
+    where block_time >= timestamp '{{start}}'
+    group by 1
+    order by 2 desc
+    limit {{top_n_pairs}}
+),
+
+trades as (
     select
         block_time,
         amount_usd,
@@ -15,6 +27,8 @@ with trades as (
         (token_bought_amount / token_sold_amount) as project_price,
         p1.price / p0.price as dune_price
     from dex_aggregator.trades as p
+    inner join token_pairs
+        on p.token_pair = token_pairs.token_pair
     inner join prices.usd as p0
         on
             p0.contract_address = token_bought_address
@@ -25,7 +39,10 @@ with trades as (
             and p1.minute = date_trunc('minute', p.block_time)
     where
         block_time >= timestamp '{{start}}'
+        and amount_usd > 100
+        and token_bought_amount > 0
         and token_sold_amount > 0
+        and p0.price > 0
         and p1.price > 0
         and p.blockchain = '{{blockchain}}'
         and project = '{{project}}'
@@ -34,8 +51,7 @@ with trades as (
 select
     token_bought_symbol as buy_token,
     token_sold_symbol as sell_token,
-    -- geometric volume-weighted price ratio
-    exp(sum(amount_usd * ln(project_price / dune_price)) / sum(amount_usd)) as dune_price_ratio,
+    sum(amount_usd * project_price / dune_price) / sum(amount_usd) as dune_price_ratio,
     sum(amount_usd) as volume
 from trades
 group by 1, 2

--- a/cowprotocol/execution_quality/aggregator_markout_4334277.sql
+++ b/cowprotocol/execution_quality/aggregator_markout_4334277.sql
@@ -1,0 +1,38 @@
+-- Computes the volume weighted price ratio between the specified aggregator and dune prices at the time of trade per token pair.
+-- A ratio >1 means the aggregator is providing better prices
+--
+-- Parameters:
+--  {{project}} - The aggregator to look at
+--  {{start}} - Start date for when trades should be counted
+--  {{blockchain}} - The chain on which trades should be counted
+
+with trades as(
+    select 
+        block_time, 
+        amount_usd, 
+        (token_bought_amount/token_sold_amount) as project_price,
+        p1.price/p0.price as dune_price,
+        token_bought_symbol, 
+        token_sold_symbol
+    from dex_aggregator.trades p
+    join prices.usd p0 
+        on p0.contract_address = token_bought_address 
+        and p0.minute = date_trunc('minute',p.block_time)
+    join prices.usd p1 
+        on p1.contract_address = token_sold_address 
+        and p1.minute = date_trunc('minute',p.block_time)
+    where block_time >= timestamp '{{start}}'
+    and token_sold_amount > 0
+    and p1.price > 0
+    and p.blockchain = '{{blockchain}}'
+    and project = '{{project}}'
+)
+
+select 
+    token_bought_symbol as buy_token, 
+    token_sold_symbol as sell_token,
+    -- geometric volume-weighted price ratio
+    exp(sum(amount_usd*ln(project_price/dune_price))/sum(amount_usd)) as dune_price_ratio,
+    sum(amount_usd) as volume
+from trades
+group by 1,2

--- a/cowprotocol/execution_quality/comparison_4334259.sql
+++ b/cowprotocol/execution_quality/comparison_4334259.sql
@@ -1,0 +1,33 @@
+-- Computes the volume weighted ratio between the markouts of two dex aggregator projects (compared to Dune prices) per token pair.
+-- A value >1 means that project_a is providing better execution than project_b
+--
+-- Parameters:
+--  {{project_a}} - The first aggregator to look at
+--  {{project_b}} - The aggregator to compare with
+--  {{start}} - Start date for when trades should be counted
+--  {{blockchain}} - The chain on which trades should be counted
+--  {{top_n_tokens}} - Based on trading volume (of project_a) how many of the top token pairs to consider
+
+with comparison as(
+    select 
+        p1.buy_token, 
+        p1.sell_token, 
+        p1.dune_price_ratio as project_a_price_ratio, 
+        p1.volume as project_a_volume, 
+        p2.dune_price_ratio as project_b_price_ratio, 
+        p2.volume as project_b_volume, 
+        p1.dune_price_ratio/p2.dune_price_ratio as project_a_advantage
+    from "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_a}}')" p1
+    join "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_b}}')" p2
+        on p1.buy_token = p2.buy_token
+        and p1.sell_token = p2.sell_token
+    where p1.volume > 0
+    and p2.volume > 0
+    order by p1.volume desc
+    limit {{top_n_tokens}}
+)
+select 
+    -- geometric volume-weighted price ratio
+    exp(sum(project_b_volume*ln(project_a_advantage))/sum(project_b_volume)) as avg_project_a_advantage,
+    count(project_b_volume) as pairs
+from comparison

--- a/cowprotocol/execution_quality/comparison_4334259.sql
+++ b/cowprotocol/execution_quality/comparison_4334259.sql
@@ -8,26 +8,29 @@
 --  {{blockchain}} - The chain on which trades should be counted
 --  {{top_n_tokens}} - Based on trading volume (of project_a) how many of the top token pairs to consider
 
-with comparison as(
-    select 
-        p1.buy_token, 
-        p1.sell_token, 
-        p1.dune_price_ratio as project_a_price_ratio, 
-        p1.volume as project_a_volume, 
-        p2.dune_price_ratio as project_b_price_ratio, 
-        p2.volume as project_b_volume, 
-        p1.dune_price_ratio/p2.dune_price_ratio as project_a_advantage
-    from "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_a}}')" p1
-    join "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_b}}')" p2
-        on p1.buy_token = p2.buy_token
-        and p1.sell_token = p2.sell_token
-    where p1.volume > 0
-    and p2.volume > 0
+with comparison as (
+    select
+        p1.buy_token,
+        p1.sell_token,
+        p1.dune_price_ratio as project_a_price_ratio,
+        p1.volume as project_a_volume,
+        p2.dune_price_ratio as project_b_price_ratio,
+        p2.volume as project_b_volume,
+        p1.dune_price_ratio / p2.dune_price_ratio as project_a_advantage
+    from "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_a}}')" as p1
+    inner join "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_b}}')" as p2
+        on
+            p1.buy_token = p2.buy_token
+            and p1.sell_token = p2.sell_token
+    where
+        p1.volume > 0
+        and p2.volume > 0
     order by p1.volume desc
     limit {{top_n_tokens}}
 )
-select 
+
+select
     -- geometric volume-weighted price ratio
-    exp(sum(project_b_volume*ln(project_a_advantage))/sum(project_b_volume)) as avg_project_a_advantage,
+    exp(sum(project_b_volume * ln(project_a_advantage)) / sum(project_b_volume)) as avg_project_a_advantage,
     count(project_b_volume) as pairs
 from comparison

--- a/cowprotocol/execution_quality/comparison_4334259.sql
+++ b/cowprotocol/execution_quality/comparison_4334259.sql
@@ -6,7 +6,7 @@
 --  {{project_b}} - The aggregator to compare with
 --  {{start}} - Start date for when trades should be counted
 --  {{blockchain}} - The chain on which trades should be counted
---  {{top_n_tokens}} - Based on trading volume (of project_a) how many of the top token pairs to consider
+--  {{top_n_pairs}} - Based on total DEX trading volume how many of the top token pairs to consider
 
 with comparison as (
     select
@@ -17,20 +17,17 @@ with comparison as (
         p2.dune_price_ratio as project_b_price_ratio,
         p2.volume as project_b_volume,
         p1.dune_price_ratio / p2.dune_price_ratio as project_a_advantage
-    from "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_a}}')" as p1
-    inner join "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_b}}')" as p2
+    from "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_a}}',top_n_pairs='{{top_n_pairs}}')" as p1
+    inner join "query_4334277(start='{{start}}',blockchain='{{blockchain}}',project='{{project_b}}',top_n_pairs='{{top_n_pairs}}')" as p2
         on
             p1.buy_token = p2.buy_token
             and p1.sell_token = p2.sell_token
     where
         p1.volume > 0
         and p2.volume > 0
-    order by p1.volume desc
-    limit {{top_n_tokens}}
 )
 
 select
-    -- geometric volume-weighted price ratio
-    exp(sum(project_b_volume * ln(project_a_advantage)) / sum(project_b_volume)) as avg_project_a_advantage,
+    (sum(project_a_volume * project_a_price_ratio) / sum(project_a_volume)) / (sum(project_b_volume * project_b_price_ratio) / sum(project_b_volume)) as avg_project_a_advantage,
     count(project_b_volume) as pairs
 from comparison


### PR DESCRIPTION
This query is based off of @PoloX2021 query to compare our execution quality with Paraswap on Aave tokens (cf. https://dune.com/queries/4274948?number_tokens_t6c1ea=100) but allowing to chose arbitrary aggregators/chains to compare with.

The basic idea is to compute "t0 markout" of trades with the Dune price table for both competitors and then volume weight the ratio of those markouts to get a total edge.

I noticed an issue in the original query that was simply computing `sum(volume * improvement) / sum(volume)` that it overcounts "positive improvements" and thus doesn't lead to symmetric results (ie. you may find when comparing Paraswap to CoW that Paraswap is better, and when comparing CoW to Paraswap that CoW is better).

This is addressed by using a geometric volume weighted average (taking the logarithm and then exp-ing the result). The intuition being, that if there are two trades of $100 one in which project A was 2x better than project B, and one where project B was 2x better than project A, the total comparision should yield 1 (projects are equally good).

In the old version, we would have
```
(100 * 2) + (100 * 0.5) / (100 + 100) = 1.25
```

Now we have

```
exp((100 * ln(2)) + (100 * ln(0.5)) / (100 + 100)) = 1
```

Also would kindly ask @fhenneke for feedback on if this math checks out.