### PR TITLE
Revert pr76 changes that are related to payouts

### DIFF
--- a/cowprotocol/accounting/cost_coverage/cost_coverage_2601653.sql
+++ b/cowprotocol/accounting/cost_coverage/cost_coverage_2601653.sql
@@ -76,18 +76,18 @@ outgoing_cow as (
 conversion_prices as (
     select
         (
-            select avg(price) from prices.minute
+            select avg(price) from prices.usd
             where
                 blockchain = 'ethereum'
                 and contract_address = 0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab
-                and date(timestamp) = cast('{{end_time}}' as timestamp) - interval '1' day
+                and date(minute) = cast('{{end_time}}' as timestamp) - interval '1' day
         ) as cow_price,
         (
-            select avg(price) from prices.minute
+            select avg(price) from prices.usd
             where
                 blockchain = 'ethereum'
                 and contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-                and date(timestamp) = cast('{{end_time}}' as timestamp) - interval '1' day
+                and date(minute) = cast('{{end_time}}' as timestamp) - interval '1' day
         ) as eth_price
 ),
 

--- a/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
+++ b/cowprotocol/accounting/price_feed/raw_price_feed_query_4252674.sql
@@ -26,7 +26,7 @@ with imported_prices as (
 imported_prices_per_minute as (
     select -- noqa: ST06
         token_address,
-        date_trunc('minute', time) as timestamp, --noqa: RF04
+        date_trunc('minute', time) as minute, --noqa: RF04
         decimals,
         source,
         avg(price_unit_eth) as price_unit_eth
@@ -42,13 +42,13 @@ imported_prices_per_minute_with_usd_prices as (
         ippm.price_unit_eth * p.price as price_unit,
         ippm.price_unit_eth * p.price / pow(10, ippm.decimals) as price_atom,
         source
-    from imported_prices_per_minute as ippm inner join prices.minute as p on ippm.timestamp = p.timestamp
+    from imported_prices_per_minute as ippm inner join prices.usd as p on ippm.minute = p.minute
     where p.contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 and blockchain = 'ethereum'
 )
 
 select -- noqa: ST06
     token_address,
-    date_trunc('hour', timestamp) as hour, --noqa: RF04
+    date_trunc('hour', minute) as hour, --noqa: RF04
     decimals,
     source,
     avg(price_unit) as price_unit,

--- a/cowprotocol/accounting/rewards/mainnet/mainnet_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/mainnet/mainnet_dashboard_query_2510345.sql
@@ -50,18 +50,18 @@ fees_and_costs as (
 conversion_prices as (
     select
         (
-            select avg(price) from prices.minute
+            select avg(price) from prices.usd
             where
                 blockchain = 'ethereum'
                 and contract_address = 0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab
-                and date(timestamp) = cast('{{end_time}}' as timestamp) - interval '1' day
+                and date(minute) = cast('{{end_time}}' as timestamp) - interval '1' day
         ) as cow_price,
         (
-            select avg(price) from prices.minute
+            select avg(price) from prices.usd
             where
                 blockchain = 'ethereum'
                 and contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-                and date(timestamp) = cast('{{end_time}}' as timestamp) - interval '1' day
+                and date(minute) = cast('{{end_time}}' as timestamp) - interval '1' day
         ) as eth_price
 ),
 

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -28,16 +28,16 @@ with token_times as (
 -- Precise prices are prices from the Dune price feed.
 precise_prices as (
     select -- noqa: ST06
-        date_trunc('hour', timestamp) as hour, --noqa: RF04
+        date_trunc('hour', minute) as hour, --noqa: RF04
         token_address,
         decimals,
         avg(price) as price_unit,
         avg(price) / pow(10, decimals) as price_atom
     from
-        prices.minute
+        prices.usd
     inner join token_times
         on
-            date_trunc('hour', timestamp) = hour
+            date_trunc('hour', minute) = hour
             and contract_address = token_address
             and blockchain = '{{blockchain}}'
     group by 1, 2, 3
@@ -121,16 +121,16 @@ wrapped_native_token as (
 -- The price of the native token is reconstructed from it chain-dependent wrapped version.
 native_token_prices as (
     select -- noqa: ST06
-        date_trunc('hour', timestamp) as hour, --noqa: RF04
+        date_trunc('hour', minute) as hour, --noqa: RF04
         0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee as token_address,
         18 as decimals,
         avg(price) as price_unit,
         avg(price) / pow(10, 18) as price_atom
-    from prices.minute
+    from prices.usd
     where
         blockchain = '{{blockchain}}'
         and contract_address = (select native_token_address from wrapped_native_token)
-        and timestamp >= cast('{{start_time}}' as timestamp) and timestamp < cast('{{end_time}}' as timestamp)
+        and minute >= cast('{{start_time}}' as timestamp) and minute < cast('{{end_time}}' as timestamp)
     group by 1, 2, 3
 )
 


### PR DESCRIPTION
The changes in PR #76 that affected queries used in the payouts resulted in very strange results in a dry-run executed today.

Reverting for now so that we can have smooth payouts tomorrow and will revisit after tomorrow's payouts