### PR TITLE
[Easy] Fix usage of daily prices

### DIFF
--- a/cowamm/kpi/tvl_by_chain_4096107.sql
+++ b/cowamm/kpi/tvl_by_chain_4096107.sql
@@ -69,7 +69,7 @@ tvl as (
         pool,
         token,
         balance,
-        (balance * p.price_close) / pow(10, decimals) as tvl
+        (balance * p.price) / pow(10, decimals) as tvl
     from reserves_by_day as r
     inner join prices.day as p
         on

--- a/cowamm/kpi/tvl_by_chain_4096107.sql
+++ b/cowamm/kpi/tvl_by_chain_4096107.sql
@@ -75,6 +75,7 @@ tvl as (
         on
             r.day = p.timestamp
             and p.contract_address = token
+            and blockchain = '{{blockchain}}'
     where latest = 1
 )
 

--- a/cowamm/profitability/10k_growth/balancer_4106553.sql
+++ b/cowamm/profitability/10k_growth/balancer_4106553.sql
@@ -96,7 +96,7 @@ lp_total_supply as (
 tvl as (
     select
         l.day,
-        sum(token_balance * price_close) as tvl
+        sum(token_balance * price) as tvl
     from balancer.liquidity as l
     inner join pool
         on

--- a/cowamm/profitability/10k_growth/cow_4047078.sql
+++ b/cowamm/profitability/10k_growth/cow_4047078.sql
@@ -90,7 +90,7 @@ tvl_by_tx as (
 tvl as (
     select
         tvl_complete.day,
-        balance1 * p1.price_close + balance2 * p2.price_close as tvl
+        balance1 * p1.price + balance2 * p2.price as tvl
     from (
         -- join full date range with potentially incomplete data. This results in many rows per day (all pool balances on or before that day)
         -- rank() is then used to order join candidates by recency (rank = 1 is the latest pool balances)

--- a/cowamm/profitability/10k_growth/daily_rebalancing_4055484.sql
+++ b/cowamm/profitability/10k_growth/daily_rebalancing_4055484.sql
@@ -24,8 +24,8 @@ with date_series as (
 daily_price_change as (
     select
         ds.day,
-        p1.price_close / previous_p1.price_close as p1,
-        p2.price_close / previous_p2.price_close as p2
+        p1.price / previous_p1.price as p1,
+        p2.price / previous_p2.price as p2
     from date_series as ds
     inner join prices.day as p1
         on

--- a/cowamm/profitability/10k_growth/hodl_4086902.sql
+++ b/cowamm/profitability/10k_growth/hodl_4086902.sql
@@ -16,8 +16,8 @@ with date_series as (
 
 starting_balance as (
     select
-        5000 / p1.price_close as token_a_start,
-        5000 / p2.price_close as token_b_start
+        5000 / p1.price as token_a_start,
+        5000 / p2.price as token_b_start
     from prices.day as p1
     inner join prices.day as p2
         on
@@ -29,7 +29,7 @@ starting_balance as (
 
 select
     ds.day,
-    token_a_start * p1.price_close + token_b_start * p2.price_close as current_value_of_investment
+    token_a_start * p1.price + token_b_start * p2.price as current_value_of_investment
 from starting_balance
 cross join date_series as ds
 inner join prices.day as p1

--- a/cowamm/profitability/10k_growth/uni_v2_4047194.sql
+++ b/cowamm/profitability/10k_growth/uni_v2_4047194.sql
@@ -116,7 +116,7 @@ tvl as (
     select
         balances.day,
         balances.contract_address,
-        sum(balance * price_close / pow(10, decimals)) as tvl
+        sum(balance * price / pow(10, decimals)) as tvl
     from (
         -- turns (date, balance0, balance1) into (date, balance0) + (date, balance1)
         select

--- a/cowamm/profitability/10k_growth/uni_v2_4047194.sql
+++ b/cowamm/profitability/10k_growth/uni_v2_4047194.sql
@@ -3,6 +3,7 @@
 --  {{token_a}} - either token of the desired uni pool
 --  {{token_b}} - other token of the desired uni pool
 --  {{start}} - date as of which the analysis should run
+--  {{blockchain}} - the blockchain to evaluate this for
 
 -- Given that we might not have records every day in the source data (e.g. not every day the lp supply may change), 
 -- but still want to visualize development on a per day basis,  we create an auxiliary table with one record per 

--- a/cowamm/profitability/invariant_growth/balancer_4106329.sql
+++ b/cowamm/profitability/invariant_growth/balancer_4106329.sql
@@ -49,7 +49,7 @@ tvl as (
         l.day,
         l.pool_address,
         l.blockchain,
-        sum(token_balance * price_close) as tvl
+        sum(token_balance * price) as tvl
     from balancer.liquidity as l
     inner join pool
         on


### PR DESCRIPTION
#76 changed the use of the price query. However, `prices_daily` no longer has a `price_close` column breaking a bunch of queries.

This PR fixes this by changing the column to the appropriate `price` column.