### PR TITLE
Add new full bonding pools

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/mainnet/full_bonding_pools_query_4056263.sql
@@ -3,19 +3,29 @@
 with
 full_bonding_pools as (
     select
-        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address,
+        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address, -- deprecated
         'Gnosis' as pool_name,
-        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as initial_funder
+        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as creator
     union distinct
     select
         from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool_address,
         'CoW DAO' as pool_name,
-        from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as initial_funder
+        from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as creator
     union distinct
     select
-        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address,
+        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address, -- deprecated
         'Project Blanc' as pool_name,
-        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as initial_funder
+        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as creator
+    union distinct
+    select
+        from_hex('0x7489f267C3b43dc76e4cb190F7B55ab3297706AF') as pool_address,
+        'Gnosis DAO' as pool_name,
+        from_hex('0x717e745040b9a486f2254659E8EA7Dc7d9a72A1e') as creator
+    union distinct
+    select
+        from_hex('0xe78d5F3aba2B31C980bF5E35E05B3A55b8365b48') as pool_address,
+        'Project Blanc' as pool_name,
+        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as creator    
 )
 
 select *


### PR DESCRIPTION
This PR adds the new full bonding pools:
- Gnosis DAO: https://etherscan.io/tx/0xe6661cc048e7f00e1abe344d34f13bd616f8e25fb137279f079d10bb0fb555ed
- Project Blanc: https://etherscan.io/tx/0x20735c4b9f12fdd110e5d4f69c039ffce06f2bd4da7c92852263f5bc13d02573

It also renames the `initial_funder` column to `creator`, as it is more accurate (creator is what we are interested in as this is the address that can vouch, while there can be multiple funders)