### PR TITLE
Update and extend unusual slippage query to all chains

### DIFF
--- a/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
@@ -32,7 +32,7 @@ select  --noqa: ST06
     concat(
         '<a href="https://phalcon.blocksec.com/explorer/tx/',
         (select * from url_helper),
-        '/',
+        '/0x',
         to_hex(rpt.tx_hash),
         '" target="_blank">',
         to_hex(rpt.tx_hash),

--- a/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/mainnet/unusual_slippage_query_2332678.sql
@@ -34,7 +34,7 @@ select  --noqa: ST06
         (select * from url_helper),
         '/0x',
         to_hex(rpt.tx_hash),
-        '" target="_blank">',
+        '" target="_blank">0x',
         to_hex(rpt.tx_hash),
         '</a>'
     ) as tx_hash,


### PR DESCRIPTION
This PR updates the outdated version of the query that was in this repo (the phalcon explorer view link was missing) and also extends it to work for all chains.

Changes have already been applied and can be tested here:
https://dune.com/queries/2332678?start_time_d83555=2024-12-10+00%3A00%3A00&end_time_d83555=2024-12-17+00%3A00%3A00