### PR TITLE
Protocol fee per order class query bug fix

### DIFF
--- a/cowprotocol/accounting/fees/protocol_fees_by_order_class_3703312.sql
+++ b/cowprotocol/accounting/fees/protocol_fees_by_order_class_3703312.sql
@@ -37,7 +37,7 @@ protocol_fees_collected as (
         quote_buy_amount,
         tx_hash
     from "query_4364122(blockchain='{{blockchain}}')"
-    where block_number > (select initial_block from initial_block) and cast(order_uid as varchar) not in (select order_uid from query_3639473)
+    where block_number > (select initial_block from initial_block) and order_uid not in (select order_uid from query_3639473)
 )
 
 select


### PR DESCRIPTION
The protocol fee per order class query had a small bug, that this PR fixes. Change has already been applied.

https://dune.com/queries/3703312?end_time_d83555=2024-12-24+00%3A00%3A00&start_time_d83555=2024-12-17+00%3A00%3A00