### PR TITLE
[Revenue] Add monthly DAO revenue query

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,4 +1,4 @@
 [sqlfluff]
 dialect = ansi
-exclude_rules = L046, RF02, RF06, CP02, ST10, LT14
+exclude_rules = L046, RF02, RF06, CP02, ST10, LT14, RF05
 max_line_length = 0

--- a/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
+++ b/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
@@ -1,0 +1,42 @@
+with
+cow_fee as (
+    select
+        date_trunc('month', block_date) as date_month,
+        sum(f.protocol_fee * f.protocol_fee_native_price / pow(10, 18))
+        - coalesce(sum(case when f.partner_fee_recipient is not null then f.partner_fee * f.protocol_fee_native_price / pow(10, 18) end), 0) as total_protocol_fee_in_eth,
+        -- partner fee is calculated based on 15% cut that goes to cow dao
+        sum(case when f.partner_fee_recipient is not null then f.partner_fee * f.protocol_fee_native_price / pow(10, 18) end) as partner_fee_eth,
+        sum(case when f.partner_fee_recipient is not null then f.partner_fee * f.protocol_fee_native_price / pow(10, 18) * cast(0.15 as double) end) as partner_fee_share
+    from cow_protocol_ethereum.trades as t
+    left join "query_4364122(blockchain='ethereum')" as f
+        on
+            t.order_uid = f.order_uid
+            and t.tx_hash = f.tx_hash
+            and f.block_number > 19068880
+            and f.protocol_fee_native_price > 0
+    where
+        t.block_number > 19068880
+        and t.order_uid not in (select order_uid from query_3639473)
+    group by 1
+),
+
+mev_fee as (
+    select
+        date_trunc('month', call_block_time) as date_month,
+        sum(t.due / 1e18 / 2) as mev_blocker_fee_cow
+    from mev_blocker_ethereum.MevBlockerFeeTill_call_bill
+    cross join unnest(due) as t (due)
+    where
+        call_success = true
+    group by 1
+)
+
+select
+    c.date_month as "month",
+    partner_fee_share,
+    total_protocol_fee_in_eth,
+    mev_blocker_fee_cow,
+    coalesce(partner_fee_share, 0) + coalesce(total_protocol_fee_in_eth, 0) + coalesce(mev_blocker_fee_cow, 0) as total_cow_dao_fee
+from cow_fee as c
+left join mev_fee as m
+    on c.date_month = m.date_month

--- a/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
+++ b/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
@@ -1,3 +1,5 @@
+-- This query returns the protocol fees (per type) that CoW DAO accrues per month
+
 with
 cow_fee as (
     select

--- a/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
+++ b/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
@@ -12,10 +12,12 @@ cow_fee as (
         on
             t.order_uid = f.order_uid
             and t.tx_hash = f.tx_hash
+            -- rough block around which the DAO started accruing fees
             and f.block_number > 19068880
             and f.protocol_fee_native_price > 0
     where
         t.block_number > 19068880
+        -- some orders report unrealistic fees due to incorrect native prices
         and t.order_uid not in (select order_uid from query_3639473)
     group by 1
 ),

--- a/cowprotocol/revenue/total_dao_revenue_3690521.sql
+++ b/cowprotocol/revenue/total_dao_revenue_3690521.sql
@@ -1,0 +1,6 @@
+select
+    sum(partner_fee_share) as partner_fee_share,
+    sum(total_protocol_fee_in_eth) as total_protocol_fee_in_eth,
+    sum(mev_blocker_fee_cow) as mev_blocker_fee_cow,
+    sum(partner_fee_share) + sum(total_protocol_fee_in_eth) + sum(mev_blocker_fee_cow) as total_cow_dao_fee
+from query_3700123

--- a/cowprotocol/revenue/total_dao_revenue_3690521.sql
+++ b/cowprotocol/revenue/total_dao_revenue_3690521.sql
@@ -1,3 +1,5 @@
+-- This query returns the total protocol fees (per type) that CoW DAO accrued since inception
+
 select
     sum(partner_fee_share) as partner_fee_share,
     sum(total_protocol_fee_in_eth) as total_protocol_fee_in_eth,


### PR DESCRIPTION
One of our most important [dashboards](https://dune.com/cowprotocol/cow-revenue) isn't yet under version control. In the next few PRs I'm going to add the existing queries (corrected for the new order rewards table) and unify the dashboard to show the same statistics per chain.

This PR adds the monthly total per fee area (not yet multi-chain), which now also powers the total protocol fee query (which became a trivial `select sum(...)`