### PR TITLE
[Revenue] Per Chain Queries

### DIFF
--- a/cowprotocol/revenue/.sqlfluff
+++ b/cowprotocol/revenue/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff]
+dialect = hive
+
+[sqlfluff:templater:jinja:context]
+ui_fee_recipient=0x6b3214fD11dc91De14718DeE98Ef59bCbFcfB432
+blockchain=gnosis

--- a/cowprotocol/revenue/daily_revenue_per_chain_4514883.sql
+++ b/cowprotocol/revenue/daily_revenue_per_chain_4514883.sql
@@ -1,0 +1,27 @@
+-- This query returns the daily revenue (per type) for a given target chain
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+with prep as (
+    select
+        date(block_time) as "day",
+        sum("Limit") as "Limit",
+        sum("Market") as "Market",
+        sum("UI Fee") as "UI Fee",
+        sum("Partner Fee Share") as "Partner Fee Share"
+    from "query_4217030(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')"
+    group by 1
+)
+
+select
+    day,
+    type,
+    value
+from prep
+cross join
+    unnest(
+        array["Limit", "Market", "UI Fee", "Partner Fee Share"],
+        array["Limit", "Market", "UI Fee", "Partner Fee Share"]
+    )
+order by 1 desc

--- a/cowprotocol/revenue/totals_per_chain_4514952.sql
+++ b/cowprotocol/revenue/totals_per_chain_4514952.sql
@@ -1,0 +1,16 @@
+-- This query returns the total revenue (per type) for a given target chain
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+with per_type as (
+    select
+        type,
+        sum(value) as total
+    from "query_4514883(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')"
+    group by 1
+)
+select * from per_type
+union
+select 'Total', sum(total) from per_type
+order by 1 desc

--- a/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
+++ b/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
@@ -1,0 +1,21 @@
+-- This query returns a list of trades (one record for each order per settlement) and lists the different fees the trade incurred
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+select
+    t.block_time,
+    (protocol_fee + partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Total Fee",
+    if(protocol_fee_kind = 'surplus', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Limit",
+    if(protocol_fee_kind = 'priceimprovement', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Market",
+    if(partner_fee_recipient in ({{ui_fee_recipient}}), partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "UI Fee",
+    if(partner_fee_recipient not in ({{ui_fee_recipient}}), 0.15 * partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "Partner Fee Share",
+    t.order_uid,
+    t.tx_hash,
+    r.solver
+from "query_4364122(blockchain='{{blockchain}}')" as r
+inner join cow_protocol_{{blockchain}}.trades as t
+    on
+        r.order_uid = t.order_uid
+        and r.tx_hash = t.tx_hash
+order by block_time desc


### PR DESCRIPTION
Adds three important revenue queries per chain
1. Every trade with its potential fee parts
2. Daily totals per part
3. All time totals per part

Those queries will be used to unify the revenue dashboard and show consistent stats for all chains.