### PR TITLE
[Revenue] Add Revenue by solver/integrator per chain

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,4 +1,4 @@
 [sqlfluff]
 dialect = ansi
-exclude_rules = L046, RF02, RF06, CP02, ST10, LT14
+exclude_rules = L046, RF02, RF06, CP02, ST10, LT14, RF05
 max_line_length = 0

--- a/cowprotocol/revenue/.sqlfluff
+++ b/cowprotocol/revenue/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff]
+dialect = hive
+
+[sqlfluff:templater:jinja:context]
+ui_fee_recipient=0x6b3214fD11dc91De14718DeE98Ef59bCbFcfB432
+blockchain=gnosis

--- a/cowprotocol/revenue/daily_revenue_by_integration_per_chain_4515022.sql
+++ b/cowprotocol/revenue/daily_revenue_by_integration_per_chain_4515022.sql
@@ -1,0 +1,13 @@
+-- This query returns the daily revenue grouped by integration for a specific target chain
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+select
+    s.name,
+    date(block_time) as "day",
+    coalesce(sum("Limit"), 0) + coalesce(sum("Market"), 0) + coalesce(sum("UI Fee"), 0) + coalesce(sum("Partner Fee Share"), 0) as total
+from "query_4217030(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')" as r
+left join cow_protocol_{{blockchain}}.solvers as s
+    on r.solver = s.address
+group by 1, 2

--- a/cowprotocol/revenue/daily_revenue_by_solver_per_chain_4515000.sql
+++ b/cowprotocol/revenue/daily_revenue_by_solver_per_chain_4515000.sql
@@ -1,0 +1,13 @@
+-- This query returns the daily revenue grouped by solver for a specific target chain
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+select
+    s.name,
+    date(block_time) as "day",
+    coalesce(sum("Limit"), 0) + coalesce(sum("Market"), 0) + coalesce(sum("UI Fee"), 0) + coalesce(sum("Partner Fee Share"), 0) as total
+from "query_4217030(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')" as r
+left join cow_protocol_{{blockchain}}.solvers as s
+    on r.solver = s.address
+group by 1, 2

--- a/cowprotocol/revenue/daily_revenue_per_chain_4514883.sql
+++ b/cowprotocol/revenue/daily_revenue_per_chain_4514883.sql
@@ -1,0 +1,27 @@
+-- This query returns the daily revenue (per type) for a given target chain
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+with prep as (
+    select
+        date(block_time) as "day",
+        sum("Limit") as "Limit",
+        sum("Market") as "Market",
+        sum("UI Fee") as "UI Fee",
+        sum("Partner Fee Share") as "Partner Fee Share"
+    from "query_4217030(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')"
+    group by 1
+)
+
+select
+    day,
+    type,
+    value
+from prep
+cross join
+    unnest(
+        array["Limit", "Market", "UI Fee", "Partner Fee Share"],
+        array["Limit", "Market", "UI Fee", "Partner Fee Share"]
+    )
+order by 1 desc

--- a/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
+++ b/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
@@ -1,0 +1,42 @@
+with
+cow_fee as (
+    select
+        date_trunc('month', block_date) as date_month,
+        sum(f.protocol_fee * f.protocol_fee_native_price / pow(10, 18))
+        - coalesce(sum(case when f.partner_fee_recipient is not null then f.partner_fee * f.protocol_fee_native_price / pow(10, 18) end), 0) as total_protocol_fee_in_eth,
+        -- partner fee is calculated based on 15% cut that goes to cow dao
+        sum(case when f.partner_fee_recipient is not null then f.partner_fee * f.protocol_fee_native_price / pow(10, 18) end) as partner_fee_eth,
+        sum(case when f.partner_fee_recipient is not null then f.partner_fee * f.protocol_fee_native_price / pow(10, 18) * cast(0.15 as double) end) as partner_fee_share
+    from cow_protocol_ethereum.trades as t
+    left join "query_4364122(blockchain='ethereum')" as f
+        on
+            t.order_uid = f.order_uid
+            and t.tx_hash = f.tx_hash
+            and f.block_number > 19068880
+            and f.protocol_fee_native_price > 0
+    where
+        t.block_number > 19068880
+        and t.order_uid not in (select order_uid from query_3639473)
+    group by 1
+),
+
+mev_fee as (
+    select
+        date_trunc('month', call_block_time) as date_month,
+        sum(t.due / 1e18 / 2) as mev_blocker_fee_cow
+    from mev_blocker_ethereum.MevBlockerFeeTill_call_bill
+    cross join unnest(due) as t (due)
+    where
+        call_success = true
+    group by 1
+)
+
+select
+    c.date_month as "month",
+    partner_fee_share,
+    total_protocol_fee_in_eth,
+    mev_blocker_fee_cow,
+    coalesce(partner_fee_share, 0) + coalesce(total_protocol_fee_in_eth, 0) + coalesce(mev_blocker_fee_cow, 0) as total_cow_dao_fee
+from cow_fee as c
+left join mev_fee as m
+    on c.date_month = m.date_month

--- a/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
+++ b/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
@@ -1,3 +1,5 @@
+-- This query returns the protocol fees (per type) that CoW DAO accrues per month
+
 with
 cow_fee as (
     select

--- a/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
+++ b/cowprotocol/revenue/monthly_dao_revenue_3700123.sql
@@ -12,10 +12,12 @@ cow_fee as (
         on
             t.order_uid = f.order_uid
             and t.tx_hash = f.tx_hash
+            -- rough block around which the DAO started accruing fees
             and f.block_number > 19068880
             and f.protocol_fee_native_price > 0
     where
         t.block_number > 19068880
+        -- some orders report unrealistic fees due to incorrect native prices
         and t.order_uid not in (select order_uid from query_3639473)
     group by 1
 ),

--- a/cowprotocol/revenue/total_dao_revenue_3690521.sql
+++ b/cowprotocol/revenue/total_dao_revenue_3690521.sql
@@ -1,0 +1,6 @@
+select
+    sum(partner_fee_share) as partner_fee_share,
+    sum(total_protocol_fee_in_eth) as total_protocol_fee_in_eth,
+    sum(mev_blocker_fee_cow) as mev_blocker_fee_cow,
+    sum(partner_fee_share) + sum(total_protocol_fee_in_eth) + sum(mev_blocker_fee_cow) as total_cow_dao_fee
+from query_3700123

--- a/cowprotocol/revenue/total_dao_revenue_3690521.sql
+++ b/cowprotocol/revenue/total_dao_revenue_3690521.sql
@@ -1,3 +1,5 @@
+-- This query returns the total protocol fees (per type) that CoW DAO accrued since inception
+
 select
     sum(partner_fee_share) as partner_fee_share,
     sum(total_protocol_fee_in_eth) as total_protocol_fee_in_eth,

--- a/cowprotocol/revenue/totals_per_chain_4514952.sql
+++ b/cowprotocol/revenue/totals_per_chain_4514952.sql
@@ -10,7 +10,11 @@ with per_type as (
     from "query_4514883(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')"
     group by 1
 )
+
 select * from per_type
-union
-select 'Total', sum(total) from per_type
+union distinct
+select
+    'Total' as "type",
+    sum(total) as total
+from per_type
 order by 1 desc

--- a/cowprotocol/revenue/totals_per_chain_4514952.sql
+++ b/cowprotocol/revenue/totals_per_chain_4514952.sql
@@ -1,0 +1,16 @@
+-- This query returns the total revenue (per type) for a given target chain
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+with per_type as (
+    select
+        type,
+        sum(value) as total
+    from "query_4514883(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')"
+    group by 1
+)
+select * from per_type
+union
+select 'Total', sum(total) from per_type
+order by 1 desc

--- a/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
+++ b/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
@@ -5,9 +5,9 @@
 
 select
     t.block_time,
-    (protocol_fee + partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Total Fee",
-    if(protocol_fee_kind = 'surplus', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Limit",
-    if(protocol_fee_kind = 'priceimprovement', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Market",
+    protocol_fee / pow(10, 18) * cast(protocol_fee_native_price as double) as "Total Fee (including ext. partner fee)",
+    if(t.block_number < 19564399 or protocol_fee_kind = 'surplus', protocol_fee - coalesce(partner_fee, 0)) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Limit",
+    if(protocol_fee_kind = 'priceimprovement', protocol_fee - coalesce(partner_fee, 0)) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Market",
     if(partner_fee_recipient in ({{ui_fee_recipient}}), partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "UI Fee",
     if(partner_fee_recipient not in ({{ui_fee_recipient}}), 0.15 * partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "Partner Fee Share",
     d.app_code,

--- a/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
+++ b/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
@@ -10,6 +10,8 @@ select
     if(protocol_fee_kind = 'priceimprovement', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Market",
     if(partner_fee_recipient in ({{ui_fee_recipient}}), partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "UI Fee",
     if(partner_fee_recipient not in ({{ui_fee_recipient}}), 0.15 * partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "Partner Fee Share",
+    d.app_code,
+    t.usd_value,
     t.order_uid,
     t.tx_hash,
     r.solver
@@ -18,4 +20,6 @@ inner join cow_protocol_{{blockchain}}.trades as t
     on
         r.order_uid = t.order_uid
         and r.tx_hash = t.tx_hash
+left join dune.cowprotocol.result_cow_protocol_{{blockchain}}_app_data as d
+    on t.app_data = d.app_hash
 order by block_time desc

--- a/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
+++ b/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
@@ -1,0 +1,21 @@
+-- This query returns a list of trades (one record for each order per settlement) and lists the different fees the trade incurred
+-- Parameters:
+--  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
+--  {{blockchain}} - the chain for which to collect the data
+
+select
+    t.block_time,
+    (protocol_fee + partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Total Fee",
+    if(protocol_fee_kind = 'surplus', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Limit",
+    if(protocol_fee_kind = 'priceimprovement', protocol_fee - partner_fee) / pow(10, 18) * cast(protocol_fee_native_price as double) as "Market",
+    if(partner_fee_recipient in ({{ui_fee_recipient}}), partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "UI Fee",
+    if(partner_fee_recipient not in ({{ui_fee_recipient}}), 0.15 * partner_fee / pow(10, 18) * cast(protocol_fee_native_price as double)) as "Partner Fee Share",
+    t.order_uid,
+    t.tx_hash,
+    r.solver
+from "query_4364122(blockchain='{{blockchain}}')" as r
+inner join cow_protocol_{{blockchain}}.trades as t
+    on
+        r.order_uid = t.order_uid
+        and r.tx_hash = t.tx_hash
+order by block_time desc

--- a/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
+++ b/cowprotocol/revenue/trade_revenue_per_chain_4217030.sql
@@ -22,4 +22,5 @@ inner join cow_protocol_{{blockchain}}.trades as t
         and r.tx_hash = t.tx_hash
 left join dune.cowprotocol.result_cow_protocol_{{blockchain}}_app_data as d
     on t.app_data = d.app_hash
+where t.order_uid not in (select order_uid from query_3639473)
 order by block_time desc


### PR DESCRIPTION
This PR adds two more useful queries which compute the fee captured by solver (1) and by integration (2) for a given target chain.

These graphs can now be seen in https://dune.com/cowprotocol/cow-revenue for each chain.