### PR TITLE
Add fee columns to (unusual) slippage query

### DIFF
--- a/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
@@ -40,7 +40,10 @@ select  --noqa: ST06
     ) as tx_hash,
     slippage_usd,
     batch_value,
-    100 * slippage_usd / batch_value as relative_slippage
+    100 * slippage_usd / batch_value as relative_slippage,
+    imbalance_usd,
+    protocol_fee_usd,
+    network_fee_usd
 from results_per_tx as rpt
 inner join cow_protocol_{{blockchain}}.batches as b on rpt.tx_hash = b.tx_hash
 inner join cow_protocol_{{blockchain}}.solvers on address = rpt.solver_address

--- a/cowprotocol/accounting/slippage/slippage_4070065.sql
+++ b/cowprotocol/accounting/slippage/slippage_4070065.sql
@@ -14,6 +14,9 @@
 -- - solver_address: address of the solver executing the settlement
 -- - slippage_usd: USD value of slippage
 -- - slippage_wei: value of slippage in atoms of native token
+-- - imbalance_usd: USD value of total buffer imbalance
+-- - protocol_fee_usd: USD value of protocol fees
+-- - network_fee_usd: USD value of network fees
 --
 -- The columns of slippage_per_solver are
 -- - solver_address: address of the solver executing the settlement
@@ -33,7 +36,10 @@ slippage_per_transaction as (
         rs.tx_hash,
         solver_address,
         sum(slippage_usd) as slippage_usd,
-        sum(slippage_wei) as slippage_wei
+        sum(slippage_wei) as slippage_wei,
+        sum(if(slippage_type = 'raw_imbalance', slippage_usd, 0)) as imbalance_usd,
+        sum(if(slippage_type = 'protocol_fee', -slippage_usd, 0)) as protocol_fee_usd,
+        sum(if(slippage_type = 'network_fee', -slippage_usd, 0)) as network_fee_usd
     from "query_4059683(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}',raw_slippage_table_name='raw_slippage_breakdown')" as rs
     inner join cow_protocol_{{blockchain}}.batches as b
         on rs.tx_hash = b.tx_hash


### PR DESCRIPTION
This PR adds additional columns to the slippage and unusual slippage query. They are meant to simplify validation and debugging of payments.

- `imbalance_usd`: The total imbalance of the transaction. It is the aggregated dollar value of all raw imbalances in the different tokens.
- `protocol_fee_usd`: The total protocol fee collected in a transaction.
- `network_fee_usd`: The total network fee as recovered from the discrepancy of uniform clearing prices and effective exchange rate of trades, corrected using protocol fees.

The total slippage of a settlement then satisfies `slippage_usd = imbalance_usd - protocol_fee - network_fee`.

The queries can be tested on dune for [slippage](https://dune.com/queries/4527447?end_time_d83555=2025-01-06+00%3A00%3A00&start_time_d83555=2024-12-31+00%3A00%3A00) and [unusual slippage](https://dune.com/queries/4527495?end_time_d83555=2025-01-06+00%3A00%3A00&start_time_d83555=2024-12-31+00%3A00%3A00).