### PR TITLE
Issues with the prices.minute table

### DIFF
--- a/cowamm/tvl_by_tx_4059700.sql
+++ b/cowamm/tvl_by_tx_4059700.sql
@@ -45,7 +45,7 @@ balances_by_tx as (
 
 -- joins token balances with prices to get tvl of pool per transaction
 tvl as (
-    select
+    select distinct
         evt_block_time as block_time,
         evt_tx_hash as tx_hash,
         b.pool,


### PR DESCRIPTION
Prices.minute is doubling the output of lines. Distinct removes this issue