### PR TITLE
Fix open interval issue in rewards query

### DIFF
--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -29,7 +29,7 @@ batch_rewards as (
         end as capped_payment
     from "query_4351957(blockchain='{{blockchain}}')" as rbr
     where
-        rbr.block_deadline > (select start_block from block_range)
+        rbr.block_deadline >= (select start_block from block_range)
         and rbr.block_deadline <= (select end_block from block_range)
 ),
 
@@ -84,7 +84,7 @@ order_quotes as (
         quote_solver
     from "query_4364122(blockchain='{{blockchain}}')"
     where
-        block_number > (select start_block from block_range)
+        block_number >= (select start_block from block_range)
         and block_number <= (select end_block from block_range)
 ),
 


### PR DESCRIPTION
This PR fixes a delicate issue in the main rewards query, that has to do with the block range that determines which auctions/orders to include in the accounting.

Note that the solver rewards script uses the correct convention, while the dune query might skip at most one auction in each accounting period due to an interval being open instead of closed.

See the following relevant references in the solver rewards repo:
- https://github.com/cowprotocol/solver-rewards/blob/a3213a8ecd08bd267591f19fe4510a67b78521dc/queries/orderbook/prod_batch_rewards.sql#L14
- https://github.com/cowprotocol/solver-rewards/blob/a3213a8ecd08bd267591f19fe4510a67b78521dc/queries/orderbook/order_data.sql#L25
- https://github.com/cowprotocol/solver-rewards/blob/a3213a8ecd08bd267591f19fe4510a67b78521dc/queries/orderbook/quote_rewards.sql#L23

For more context, this is the query used to determine the start and end block of an accounting period -> https://github.com/cowprotocol/dune-queries/blob/main/cowprotocol/accounting/rewards/block_number_interval_from_time_interval_query_3333356.sql