### PR TITLE
Change prices from minute to day to avoid issues in the db

### DIFF
--- a/cowamm/tvl_by_tx_4059700.sql
+++ b/cowamm/tvl_by_tx_4059700.sql
@@ -54,9 +54,9 @@ tvl as (
         price,
         balance * price / POW(10, decimals) as tvl
     from balances_by_tx as b
-    inner join prices.minute as p
+    inner join prices.day as p
         on
-            p.timestamp = DATE_TRUNC('minute', evt_block_time)
+            p.timestamp = DATE_TRUNC('day', evt_block_time)
             and b.token = p.contract_address
 )
 


### PR DESCRIPTION
The prices.minute table is completely messed up currently. 
This PR switch to prices.day. This table is less precise because we are looking at individual transactions. But it does not impact daily performance metrics.