### PR TITLE
Fix performance kpi competitors

### DIFF
--- a/cowamm/kpi/competitors/cow_amm/tvl_all_cow_amms_4340356.sql
+++ b/cowamm/kpi/competitors/cow_amm/tvl_all_cow_amms_4340356.sql
@@ -2,13 +2,14 @@
 -- Parameters
 --  {{blockchain}} - chain for which the query is running
 
+--Use materialized view to avoid calling too many times the logs table, slowing the query
 with cow_amm_pool as (
     select
         created_at,
         address,
         token_1_address as token0,
         token_2_address as token1
-    from query_3959044
+    from dune.cowprotocol.result_balancer_co_w_am_ms
     where blockchain = '{{blockchain}}'
     order by 1 desc
 ),

--- a/cowamm/kpi/competitors/curve/curve_kpis_4232873.sql
+++ b/cowamm/kpi/competitors/curve/curve_kpis_4232873.sql
@@ -25,19 +25,19 @@ with accumulated_kpis as (
         on
             r.contract_address = t.project_contract_address
             and r.tx_hash = t.tx_hash
-    inner join prices.minute as p0
+    inner join prices.usd as p0
         on
             r.token0 = p0.contract_address
-            and date_trunc('minute', r.evt_block_time) = p0.timestamp
-    inner join prices.minute as p1
+            and date_trunc('minute', r.evt_block_time) = p0.minute
+    inner join prices.usd as p1
         on
             r.token1 = p1.contract_address
-            and date_trunc('minute', r.evt_block_time) = p1.timestamp
+            and date_trunc('minute', r.evt_block_time) = p1.minute
     where
         -- This test avoids any possible issue with reconstructing the reserves of the pool
         tvl > 0
-        and p0.timestamp between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
-        and p1.timestamp between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
+        and p0.minute between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
+        and p1.minute between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
 )
 
 select

--- a/cowamm/kpi/competitors/uni_swap_style/largest_uni_style_kpis_4304295.sql
+++ b/cowamm/kpi/competitors/uni_swap_style/largest_uni_style_kpis_4304295.sql
@@ -70,17 +70,17 @@ tvl_volume_per_swap as (
             and syncs.evt_index + 1 = swaps.evt_index
     inner join pool
         on syncs.contract_address = pool.contract_address
-    inner join prices.minute as p0
+    inner join prices.usd as p0
         on
-            date_trunc('minute', syncs.evt_block_time) = p0.timestamp
+            date_trunc('minute', syncs.evt_block_time) = p0.minute
             and syncs.token0 = p0.contract_address
-    inner join prices.minute as p1
+    inner join prices.usd as p1
         on
-            date_trunc('minute', syncs.evt_block_time) = p1.timestamp
+            date_trunc('minute', syncs.evt_block_time) = p1.minute
             and syncs.token1 = p1.contract_address
     where
-        p0.timestamp between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
-        and p1.timestamp between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
+        p0.minute between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
+        and p1.minute between least(date('{{start_time}}'), date_add('day', -1, date(now()))) and least(date_add('day', 1, date('{{start_time}}')), date(now()))
 )
 
 select


### PR DESCRIPTION
Improving the speed of some queries and reverting to the prices.usd table for accurate information.
This means we won't be supporting new tokens, but it's better than having false data for all tokens.