### PR TITLE
Fix bug with removed duplicates in balance changes

### DIFF
--- a/cowprotocol/accounting/token_imbalances/balance_changes_4021257.sql
+++ b/cowprotocol/accounting/token_imbalances/balance_changes_4021257.sql
@@ -78,7 +78,7 @@ weth_deposits_withdrawals_ethereum as (
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
         and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
+    union all
     -- withdrawals (contract withdraws ETH by returning WETH)
     select
         evt_block_time as block_time,
@@ -107,7 +107,7 @@ sdai_deposits_withdraws_ethereum as (
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
         and owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
+    union all
     -- withdraws
     select
         evt_block_time as block_time,
@@ -136,7 +136,7 @@ mkr_mint_burn_ethereum as (
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
         and guy = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
+    union all
     -- withdraws
     select
         evt_block_time as block_time,
@@ -177,7 +177,7 @@ wxdai_deposits_withdrawals_gnosis as (
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
         and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
+    union all
     -- withdrawals (contract withdraws XDAI by returning WXDAI)
     select
         evt_block_time as block_time,
@@ -214,7 +214,7 @@ weth_deposits_withdrawals_arbitrum as (
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
         and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
+    union all
     -- withdrawals (contract withdraws ETH by returning WETH)
     select
         evt_block_time as block_time,
@@ -246,7 +246,7 @@ weth_deposits_withdrawals_base as (
     where
         evt_block_time >= cast('{{start_time}}' as timestamp) and evt_block_time < cast('{{end_time}}' as timestamp) -- partition column
         and dst = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-    union distinct
+    union all
     -- withdrawals (contract withdraws ETH by returning WETH)
     select
         evt_block_time as block_time,


### PR DESCRIPTION
This PR changes how duplicates are handled in balance changes. The new query can be tested [here](https://dune.com/queries/4636979?end_time_d83555=2025-01-28+00%3A00%3A00&start_time_d83555=2025-01-21+00%3A00%3A00).

Before, with a `union distinct` all duplicate rows were removed. This led to wrongfully removing balance changes in auctions where there are multiple withdrawals of the same amount (e.g. [here](https://etherscan.io/tx/0x08afb56d779bc2034bfcc78a1d470cc82c8c55c4394fda3875d426de869f8ca2) and [here](https://etherscan.io/tx/0x74e730407d3061e60527629123c1e7b43e3e73b4ba4232bd077c7109ac5e8325)). Using `union all` removes this problem.

Comparing the new and old query for the accounting week 2025-01-21 to 2025-01-28, there are just 6 additional rows which can be traced to two settlements with duplicate withdrawals ([Dune query](https://dune.com/queries/4637074)).