### PR TITLE
[MEVBlocker] Prepare fee bump

### DIFF
--- a/mevblocker/fees/payment_due_4005800.sql
+++ b/mevblocker/fees/payment_due_4005800.sql
@@ -15,7 +15,8 @@ WITH block_range AS (
 ),
 
 final_fee AS (
-    SELECT avg_block_fee_wei
+    --TODO: remove the 2/3 once the fee increment should also be reflected in the payment due query (not just in announcing the new fee)
+    SELECT avg_block_fee_wei * 2 / 3 as avg_block_fee_wei
     FROM "query_4002039(start='{{fee_computation_start}}', end='{{fee_computation_end}}')"
 ),
 

--- a/mevblocker/fees/payment_due_4005800.sql
+++ b/mevblocker/fees/payment_due_4005800.sql
@@ -16,7 +16,7 @@ WITH block_range AS (
 
 final_fee AS (
     --TODO: remove the 2/3 once the fee increment should also be reflected in the payment due query (not just in announcing the new fee)
-    SELECT avg_block_fee_wei * 2 / 3 as avg_block_fee_wei
+    SELECT avg_block_fee_wei * 2 / 3 AS avg_block_fee_wei
     FROM "query_4002039(start='{{fee_computation_start}}', end='{{fee_computation_end}}')"
 ),
 

--- a/mevblocker/fees/value_per_tx_4188777.sql
+++ b/mevblocker/fees/value_per_tx_4188777.sql
@@ -153,7 +153,7 @@ SELECT
     COALESCE(user_tip_wei, 0) AS user_tip_wei,
     COALESCE(SUM(backrun_value_wei), 0) AS backrun_value_wei,
     COALESCE(SUM(backrun_tip_wei), 0) AS backrun_tip_wei,
-    CAST(0.2 * (COALESCE(user_tip_wei, 0) + COALESCE(SUM(backrun_tip_wei), 0) + (COALESCE(SUM(backrun_value_wei), 0) / 9)) AS UINT256) AS tx_mevblocker_fee_wei
+    CAST(0.3 * (COALESCE(user_tip_wei, 0) + COALESCE(SUM(backrun_tip_wei), 0) + (COALESCE(SUM(backrun_value_wei), 0) / 9)) AS UINT256) AS tx_mevblocker_fee_wei
 FROM user_txs AS u
 LEFT JOIN searcher_txs AS searcher
     ON u.hash = searcher.tx_1


### PR DESCRIPTION
MEVBlocker fee is increasing to 30% as of February. In order to not disrupt the billing transaction tomorrow (which should still charge 20% fee for the previous week), this PR also adjusts the "payment due " query downward to account for the old fee.

However, the per block fee that will be announced in the billing transaction and is valid for the following week already uses the 30% fee tier.

Towards the end of the week we then need to revert the change to payment due query to make sure next week the 30% fee is applied.