### PR TITLE
[MEVBlocker] cleanup after fee increase to 30%

### DIFF
--- a/mevblocker/fees/payment_due_4005800.sql
+++ b/mevblocker/fees/payment_due_4005800.sql
@@ -15,8 +15,7 @@ WITH block_range AS (
 ),
 
 final_fee AS (
-    --TODO: remove the 2/3 once the fee increment should also be reflected in the payment due query (not just in announcing the new fee)
-    SELECT avg_block_fee_wei * 2 / 3 AS avg_block_fee_wei
+    SELECT avg_block_fee_wei
     FROM "query_4002039(start='{{fee_computation_start}}', end='{{fee_computation_end}}')"
 ),
 

--- a/mevblocker/fees/value_per_tx_4188777.sql
+++ b/mevblocker/fees/value_per_tx_4188777.sql
@@ -20,8 +20,8 @@ nonexclusive_flow AS (
     WHERE
         included_at_block_height >= (SELECT start_block FROM block_range)
         AND included_at_block_height < (SELECT end_block FROM block_range)
-    UNION
-    SELECT DISTINCT cast(hash as varchar)
+    UNION DISTINCT
+    SELECT DISTINCT CAST(hash AS varchar)
     FROM dune.gattacahq.mev_blocker_non_exclusive_txs
     WHERE
         block_timestamp >= TIMESTAMP '{{start}}'
@@ -58,8 +58,8 @@ mev_blocker_tx AS (
         et.block_time,
         et.gas_used,
         et.gas_price,
-        FROM_HEX(CAST(JSON_EXTRACT(mb.transactions, '$[0].hash') AS VARCHAR)) AS tx_1,
-        FROM_HEX(CAST(JSON_EXTRACT(mb.transactions, '$[0].from') AS VARCHAR)) AS tx_from_1,
+        FROM_HEX(CAST(JSON_EXTRACT(mb.transactions, '$[0].hash') AS varchar)) AS tx_1,
+        FROM_HEX(CAST(JSON_EXTRACT(mb.transactions, '$[0].from') AS varchar)) AS tx_from_1,
         FROM_HEX(jt.hash) AS hash
     FROM
         mev_blocker_filtered AS mb
@@ -68,7 +68,7 @@ mev_blocker_tx AS (
             mb.transactions,
             'lax $[*]' COLUMNS(
                 row_number for ordinality,
-                hash VARCHAR(255) PATH 'lax $.hash'
+                hash VARCHAR(255) path 'lax $.hash'
             )
         ) AS jt
     INNER JOIN ethereum_transactions_filtered AS et
@@ -117,7 +117,7 @@ kickback_txs AS (
         st.search_tx,
         st.tx_1 AS target_tx,
         value AS backrun_value_wei,
-        CAST(et.gas_used AS UINT256) * (et.gas_price - COALESCE(b.base_fee_per_gas, 0)) AS backrun_tip_wei
+        CAST(et.gas_used AS uint256) * (et.gas_price - COALESCE(b.base_fee_per_gas, 0)) AS backrun_tip_wei
     FROM searcher_txs AS st
     INNER JOIN ethereum_transactions_filtered AS et
         ON
@@ -139,12 +139,12 @@ user_txs AS (
         tx.block_time,
         tx.block_number,
         tx.hash,
-        CAST(tx.gas_used AS UINT256) * (tx.gas_price - COALESCE(b.base_fee_per_gas, 0)) AS user_tip_wei
+        CAST(tx.gas_used AS uint256) * (tx.gas_price - COALESCE(b.base_fee_per_gas, 0)) AS user_tip_wei
     FROM mev_blocker_tx AS tx
     LEFT JOIN ethereum.blocks AS b ON block_number = number
     WHERE
         tx.hash NOT IN (SELECT search_tx FROM searcher_txs)
-        AND CAST(tx.hash AS VARCHAR) NOT IN (SELECT hash FROM nonexclusive_flow)
+        AND CAST(tx.hash AS varchar) NOT IN (SELECT hash FROM nonexclusive_flow)
     -- deduplicate approve txs that appear in bundles and individually
     GROUP BY 1, 2, 3, 4
 )
@@ -159,7 +159,7 @@ SELECT
     COALESCE(user_tip_wei, 0) AS user_tip_wei,
     COALESCE(SUM(backrun_value_wei), 0) AS backrun_value_wei,
     COALESCE(SUM(backrun_tip_wei), 0) AS backrun_tip_wei,
-    CAST(0.3 * (COALESCE(user_tip_wei, 0) + COALESCE(SUM(backrun_tip_wei), 0) + (COALESCE(SUM(backrun_value_wei), 0) / 9)) AS UINT256) AS tx_mevblocker_fee_wei
+    CAST(0.3 * (COALESCE(user_tip_wei, 0) + COALESCE(SUM(backrun_tip_wei), 0) + (COALESCE(SUM(backrun_value_wei), 0) / 9)) AS uint256) AS tx_mevblocker_fee_wei
 FROM user_txs AS u
 LEFT JOIN searcher_txs AS searcher
     ON u.hash = searcher.tx_1


### PR DESCRIPTION
This PR is a follow up to #132, it 
1. Removes the temporary fee reduction (as last week we were still charging a 20% fee) for billing purposes so that as of next week we not only announce but also charge the new fee
2. Includes Titan's table for which transaction hashes were not exclusive to MEV Blocker. Those should be excluded for billing purposes.

Note, that this PR needs to be merged before next Wednesday to take effect in the payouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**  
	- Adjusted fee calculations so fees now reflect the complete average value, ensuring weekly fees and amounts due are accurate.  
	- Refined the processing of transaction data to more precisely distinguish exclusive transactions, improving the accuracy of reported results.  
	- Updated filtering logic for user transactions to include a broader scope of transactions in the analysis.  
	- Standardized data type usage across the script for consistency.  
	- Renamed variables for clarity without altering functionality in calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->