### PR TITLE
fix sqlfluff issue in cow amm profitability 10k growth queries

### DIFF
--- a/cowamm/profitability/10k_growth/balancer_4106553.sql
+++ b/cowamm/profitability/10k_growth/balancer_4106553.sql
@@ -131,9 +131,9 @@ select
     lp_token_price,
     (
         -- Assess initial investment in lp tokens
-        select 10000 / lp_token_price as investment
-        from lp_token_price
-        where day = timestamp '{{start}}'
+        select 10000 / lptp.lp_token_price as investment
+        from lp_token_price as lptp
+        where lptp.day = timestamp '{{start}}'
     ) * lp_token_price as current_value_of_investment
 from lp_token_price
 order by 1 desc

--- a/cowamm/profitability/10k_growth/cow_4047078.sql
+++ b/cowamm/profitability/10k_growth/cow_4047078.sql
@@ -140,9 +140,9 @@ select
     lp_token_price,
     (
         -- Assess initial investment in lp tokens
-        select 10000 / lp_token_price as investment
-        from final
-        where day = timestamp '{{start}}'
+        select 10000 / f.lp_token_price as investment
+        from final as f
+        where f.day = timestamp '{{start}}'
     ) * lp_token_price as current_value_of_investment
 from final
 where day >= timestamp '{{start}}'

--- a/cowamm/profitability/10k_growth/uni_v2_4047194.sql
+++ b/cowamm/profitability/10k_growth/uni_v2_4047194.sql
@@ -162,9 +162,9 @@ select
     lp_token_price,
     (
         -- Assess initial investment in lp tokens
-        select 10000 / lp_token_price as investment
-        from lp_token_price
-        where day = timestamp '{{start}}'
+        select 10000 / lptp.lp_token_price as investment
+        from lp_token_price as lptp
+        where lptp.day = timestamp '{{start}}'
     ) * lp_token_price as current_value_of_investment
 from lp_token_price
 order by day desc


### PR DESCRIPTION
This PR addresses these errors

```
Run sqlfluff lint .
== [cowamm/profitability/10k_growth/balancer_4106553.sql] FAIL
L: 138 | P:   6 | AL04 | Duplicate table alias 'lp_token_price'. Table aliases
                       | should be unique. [aliasing.unique.table]
== [cowamm/profitability/10k_growth/cow_4047078.sql] FAIL
L: 147 | P:   6 | AL04 | Duplicate table alias 'final'. Table aliases should be
                       | unique. [aliasing.unique.table]
== [cowamm/profitability/10k_growth/uni_v2_4047194.sql] FAIL
L: 169 | P:   6 | AL04 | Duplicate table alias 'lp_token_price'. Table aliases
                       | should be unique. [aliasing.unique.table]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal database queries for calculating liquidity provider token investments. These updates improve code clarity and maintain the consistency of the results without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->