### PR TITLE
Fix service fee query

### DIFF
--- a/cowprotocol/accounting/rewards/service_fee_query_4298142.sql
+++ b/cowprotocol/accounting/rewards/service_fee_query_4298142.sql
@@ -121,6 +121,7 @@ select
     coalesce(e.pool_name, d.pool_name) as pool_name,
     case
         when e.creation_date > date_add('month', -3, cast('{{start_time}}' as timestamp)) then false
+        when e.creation_date <= date_add('month', -3, cast('{{start_time}}' as timestamp)) then true
         else d.service_fee_flag
     end as service_fee
 from active_cow_dao_solvers_service_fee as d left outer join reduced_bonds as e on d.solver_address = e.solver_address


### PR DESCRIPTION
The query assumed, implicitly (this was not really intended), that every colocated solver with a reduced pool had initially joined the CoW DAO bonding pool at least 3 months before creating the reduced pool. This caused some issues, with Portus, for example. This is a bug, and this PR adds an explicit check so as to ensure that solvers that joined the CoW DAO bonding pool AND created a subpool within an interval of 3 months will start paying a service fee after 3 months. Specifically for Portus, there is no ambiguity around this as they joined a long time ago and only got renamed (which revealed the issue in the first place)