### PR TITLE
[MEV Blocker] Prepare Fee Bump

### DIFF
--- a/mevblocker/fees/payment_due_4005800.sql
+++ b/mevblocker/fees/payment_due_4005800.sql
@@ -15,6 +15,7 @@ WITH block_range AS (
 ),
 
 final_fee AS (
+    -- TODO: remove between  2025/03/06 and 2025/03/11
     SELECT avg_block_fee_wei * 3 / 4 AS avg_block_fee_wei
     FROM "query_4002039(start='{{fee_computation_start}}', end='{{fee_computation_end}}')"
 ),

--- a/mevblocker/fees/payment_due_4005800.sql
+++ b/mevblocker/fees/payment_due_4005800.sql
@@ -15,7 +15,7 @@ WITH block_range AS (
 ),
 
 final_fee AS (
-    SELECT avg_block_fee_wei
+    SELECT avg_block_fee_wei * 3 / 4 AS avg_block_fee_wei
     FROM "query_4002039(start='{{fee_computation_start}}', end='{{fee_computation_end}}')"
 ),
 

--- a/mevblocker/fees/value_per_tx_4188777.sql
+++ b/mevblocker/fees/value_per_tx_4188777.sql
@@ -166,7 +166,7 @@ SELECT
     COALESCE(SUM(backrun_tip_wei), 0) AS backrun_tip_wei,
     -- in practice there is only a single refund recipient per target transaction. Collapsing using the largest is a bit hacky but should work.
     MAX(refund_recipient) AS refund_recipient,
-    CAST(0.3 * (COALESCE(user_tip_wei, 0) + COALESCE(SUM(backrun_tip_wei), 0) + (COALESCE(SUM(backrun_value_wei), 0) / 9)) AS uint256) AS tx_mevblocker_fee_wei
+    CAST(0.4 * (COALESCE(user_tip_wei, 0) + COALESCE(SUM(backrun_tip_wei), 0) + (COALESCE(SUM(backrun_value_wei), 0) / 9)) AS uint256) AS tx_mevblocker_fee_wei
 FROM user_txs AS u
 LEFT JOIN searcher_txs AS searcher
     ON u.hash = searcher.tx_1


### PR DESCRIPTION
Increase fees from 30% to 40%. At the same time keep payments due at 30% fee.
Price reduction to be reverted after next payment (5 Mar 2025).