### PR TITLE
Fix BNKR price on Base for week of March 4-11, 2025

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -82,7 +82,7 @@ intrinsic_prices as (
 
 -- The final price is the Dune price if it exists and the intrinsic price otherwise. If both prices
 -- are not available, the price is null.
-prices as (
+prices_pre as (
     select
         tt.hour,
         tt.token_address,
@@ -107,6 +107,22 @@ prices as (
         on
             tt.hour = intrinsic.hour
             and tt.token_address = intrinsic.token_address
+),
+
+prices as (
+    select
+        hour,
+        token_address,
+        decimals,
+        case
+            when token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585
+            else price_unit
+        end as price_unit,
+        case
+            when token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585 / pow(10, 18)
+            else price_atom
+        end as price_atom
+    from prices_pre
 ),
 
 wrapped_native_token as (

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -115,11 +115,11 @@ prices as (
         token_address,
         decimals,
         case
-            when token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585
+            when '{{blockchain}}' = 'base' and token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585
             else price_unit
         end as price_unit,
         case
-            when token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585 / pow(10, 18)
+            when '{{blockchain}}' = 'base' and token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585 / pow(10, 18)
             else price_atom
         end as price_atom
     from prices_pre


### PR DESCRIPTION
This PR hardcodes the price of `0x22af33fe49fd1fa80c7149773dde5890d3c76f3b` for the week of March 4-11, 2025, as it is currently completely off.

To see this, you can use the current version of the query, and check the price of that token by setting, for example, start time being March 8 and end time being March 10; https://dune.com/queries/4064601?start_time_d83555=2025-03-08+00%3A00%3A00&end_time_d83555=2025-03-10+00%3A00%3A00&blockchain_t6c1ea=base.

The updated query can be found here:
https://dune.com/queries/4836344