### PR TITLE
Remove service fee scaling for negative rewards

### DIFF
--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -153,8 +153,14 @@ combined_data_after_service_fee as (
         cd.solver,
         cd.network_fee_eth,
         cd.execution_cost_eth,
-        coalesce(sff.service_fee_factor, 1) * cd.primary_reward_eth as primary_reward_eth,
-        coalesce(sff.service_fee_factor, 1) * cd.primary_reward_cow as primary_reward_cow,
+        case
+            when cd.primary_reward_eth < 0 then cd.primary_reward_eth
+            else coalesce(sff.service_fee_factor, 1) * cd.primary_reward_eth
+        end as primary_reward_eth,
+        case
+            when cd.primary_reward_cow < 0 then cd.primary_reward_cow
+            else coalesce(sff.service_fee_factor, 1) * cd.primary_reward_cow
+        end as primary_reward_cow,
         coalesce(sff.service_fee_factor, 1) * cd.quote_reward as quote_reward,
         cd.slippage_eth,
         cd.slippage_per_tx,


### PR DESCRIPTION
This PR removes the scaling with the service fee that was accidentally done when rewards are negative, and aligns the Dune's dahsboard behavior with what the solver rewards script computes.