### PR TITLE
Update phalcon explorer url in unusual slippage query

### DIFF
--- a/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
@@ -30,7 +30,7 @@ select  --noqa: ST06
         '" target="_blank">link</a>'
     ) as token_breakdown,
     concat(
-        '<a href="https://phalcon.blocksec.com/explorer/tx/',
+        '<a href="https://app.blocksec.com/explorer/tx/',
         (select * from url_helper),
         '/0x',
         to_hex(rpt.tx_hash),


### PR DESCRIPTION
Small change in the url, so link in query needs to be updated