### PR TITLE
Exclude tx with scam token

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -210,6 +210,9 @@ where
     -- for week of March 4 - March 11, 2025 on mainnet
     or tx_hash = 0x1F14B47CCA77FBA18F6AD87372C9F942617FAF9C787622BBD8F56D187EF069FA
 
+    -- for week of April 15 - April 22, 2025 on mainnet
+    or tx_hash = 0x91f810f43903c11b99ccb6b4deeda464261b655b0bd546ef4edbcfdd6bad5ddd
+
 -- Base
 union all
 select distinct tx_hash


### PR DESCRIPTION
Garbage token that was denylisted, where owners could transfer out from the settlement contract (see [here](https://etherscan.io/tx/0x6259db0f1bac7ecc9b69cb35ea3b6432c799ce6031c85abefa62518ba22e530f))