### PR TITLE
Prevent Duplicate Counting in Solver Metrics by Pre-Aggregating Trades

### DIFF
--- a/cowprotocol/solver_dashboard/ranked_active_solvers_1756858.sql
+++ b/cowprotocol/solver_dashboard/ranked_active_solvers_1756858.sql
@@ -3,32 +3,59 @@
 -- Parameters:
 --   {{last_n_days}}: int the number of days to look back
 
-with solver_info as (
-    select
-        name as solver_name,
-        -- concat(environment, '-', name) as name,
-        max(b.block_time) as last_solution,
-        count(*) as batches_solved,
-        sum(dex_swaps) as dex_swaps,
-        sum(num_trades) as num_trades,
-        sum(gas_used) as gas_used,
-        sum(batch_value) as total_batch_value,
-        avg(batch_value) as average_batch_volume,
-        avg(num_trades) as average_batch_size,
-        sum(surplus_usd) as total_surplus,
-        1.0 * sum(gas_used) / sum(num_trades) as average_gas_per_trade,
-        1.0 * sum(dex_swaps) / sum(num_trades) as average_dex_swaps_per_trade
-    from cow_protocol_{{blockchain}}.batches as b
-    inner join cow_protocol_{{blockchain}}.solvers on solver_address = address
-    inner join cow_protocol_{{blockchain}}.trades as t
-        on b.tx_hash = t.tx_hash
-    where environment not in ('test', 'service') and t.block_date > now() - interval '{{last_n_days}}' day and active = True
-    group by name
-    order by num_trades desc
+WITH settled_batches AS (
+    SELECT DISTINCT tx_hash
+    FROM cow_protocol_{{blockchain}}.trades
+    WHERE block_date > now() - interval '{{last_n_days}}' day
+),
+
+trade_agg AS (
+    SELECT
+        tx_hash,
+        COUNT(*) AS num_trades,
+        SUM(surplus_usd) AS surplus_usd
+    FROM cow_protocol_{{blockchain}}.trades
+    WHERE block_date > now() - interval '{{last_n_days}}' day
+    GROUP BY tx_hash
+),
+
+settled_batch_data AS (
+    SELECT
+        b.tx_hash,
+        b.block_time,
+        b.solver_address,
+        b.batch_value,
+        b.gas_used,
+        b.dex_swaps
+    FROM cow_protocol_{{blockchain}}.batches b
+    INNER JOIN settled_batches sb ON b.tx_hash = sb.tx_hash
+),
+
+solver_info AS (
+    SELECT
+        s.name AS solver_name,
+        MAX(b.block_time) AS last_solution,
+        COUNT(*) AS batches_solved,
+        SUM(b.dex_swaps) AS dex_swaps,
+        SUM(t.num_trades) AS num_trades,
+        SUM(b.gas_used) AS gas_used,
+        SUM(b.batch_value) AS total_batch_value,
+        AVG(b.batch_value) AS average_batch_volume,
+        AVG(t.num_trades) AS average_batch_size,
+        SUM(t.surplus_usd) AS total_surplus,
+        1.0 * SUM(b.gas_used) / NULLIF(SUM(t.num_trades), 0) AS average_gas_per_trade,
+        1.0 * SUM(b.dex_swaps) / NULLIF(SUM(t.num_trades), 0) AS average_dex_swaps_per_trade
+    FROM settled_batch_data b
+    INNER JOIN cow_protocol_{{blockchain}}.solvers s
+        ON b.solver_address = s.address
+    INNER JOIN trade_agg t
+        ON b.tx_hash = t.tx_hash
+    WHERE s.environment NOT IN ('test', 'service') AND s.active = TRUE
+    GROUP BY s.name
 )
 
-select -- noqa: ST06
-    row_number() over (order by average_gas_per_trade) as rk,
+SELECT -- noqa: ST06
+    ROW_NUMBER() OVER (ORDER BY average_gas_per_trade) AS rk,
     *
-from solver_info
-order by rk
+FROM solver_info
+ORDER BY rk;


### PR DESCRIPTION
### Overview

This PR fixes a data integrity issue in the `V2: Ranked Active Solvers` Dune query, where solver metrics were **inflated due to row duplication** caused by directly joining `batches` with `trades` using `tx_hash`.

### What was wrong?

- The original query included:
  ```sql
  INNER JOIN trades t ON b.tx_hash = t.tx_hash
  ```
  Since many batches have multiple trades, this caused row multiplication, leading to overcounting.
  
 ### What’s changed?
- Added a trade_agg CTE to aggregate trade metrics per tx_hash.

- Joined batches to this pre-aggregated view to avoid row duplication.

- Ensured only settled batches (those with at least one trade) are included by joining against trade_agg.

- Preserved solver-level filters (environment NOT IN ('test', 'service'), active = TRUE).