### PR TITLE
Migrate missing refunds to query used in production

### DIFF
--- a/cowprotocol/ethflow/missing_refunds_4904398.sql
+++ b/cowprotocol/ethflow/missing_refunds_4904398.sql
@@ -6,6 +6,7 @@
 --  {{start_time}} - the order validity timestamp for which the analysis should start (inclusive)
 --  {{end_time}} - the order validity timestamp for which the analysis should end (inclusive)
 --  {{grace_period}} - a global shift of start and end time to account for delays in refunds
+--  {{network}} - the network to be used (e.g. ethereum, gnosis, etc.)
 
 with
 join_with_trade_events as (
@@ -20,8 +21,8 @@ join_with_trade_events as (
         block_number as placement_block,
         evt_block_number as fill_block,
         order_uid
-    from cow_protocol_ethereum.eth_flow_orders
-    left outer join gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade
+    from cow_protocol_{{network}}.eth_flow_orders
+    left outer join gnosis_protocol_v2_{{network}}.GPv2Settlement_evt_Trade
         on
             order_uid = orderUid
             and evt_block_time > block_time
@@ -35,8 +36,8 @@ cancellations as (
         evt_block_time as cancellation_time,
         evt_block_number as cancellation_block,
         sum(cast(value as double) / pow(10, 18)) as refund_amount_eth
-    from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderInvalidation
-    inner join ethereum.tracess
+    from cow_protocol_{{network}}.CoWSwapEthFlow_evt_OrderInvalidation
+    inner join {{network}}.traces
         on
             evt_block_number = block_number
             and evt_tx_hash = tx_hash
@@ -52,8 +53,8 @@ refunds as (
         refunder,
         orderUid,
         sum(cast(value as double) / pow(10, 18)) as refund_amount_eth
-    from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderRefund
-    inner join ethereum.traces
+    from cow_protocol_{{network}}.CoWSwapEthFlow_evt_OrderRefund
+    inner join {{network}}.traces
         on
             evt_block_number = block_number
             and evt_tx_hash = tx_hash


### PR DESCRIPTION
In #53 we migrated the missing refunds query, which [alerts](https://cowservices.slack.com/archives/C0371SB243E/p1747846829371189) us whenever there is a non-refunded ETH flow order into this repository.

It turns out that the alert is using a slightly different query (which seems to have been adopted to provide multi network support).

This PR moves the tracked query to be pointing to the one that is used in production (and backports the required multi network changes).

In a follow up PR, I'd like to introduce a list of app codes for which we do not alert as we have some integrations which are placing native ETH orders in a way that we are not willing to perform automatic refunds.

## Test Plan

Copy past query into https://dune.com/queries/4904398, see it still runs.