### PR TITLE
[ETH Flow Missing Refund] Add variable to ignore certain app codes

### DIFF
--- a/cowprotocol/ethflow/.sqlfluff
+++ b/cowprotocol/ethflow/.sqlfluff
@@ -3,3 +3,4 @@ start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
 grace_period=10
 network='ethereum'
+ignored_app_codes=''

--- a/cowprotocol/ethflow/.sqlfluff
+++ b/cowprotocol/ethflow/.sqlfluff
@@ -2,3 +2,4 @@
 start_time='2024-08-20 00:00:00'
 end_time='2024-08-27 00:00:00'
 grace_period=10
+network='ethereum'

--- a/cowprotocol/ethflow/missing_refunds_4904398.sql
+++ b/cowprotocol/ethflow/missing_refunds_4904398.sql
@@ -6,6 +6,7 @@
 --  {{start_time}} - the order validity timestamp for which the analysis should start (inclusive)
 --  {{end_time}} - the order validity timestamp for which the analysis should end (inclusive)
 --  {{grace_period}} - a global shift of start and end time to account for delays in refunds
+--  {{network}} - the network to be used (e.g. ethereum, gnosis, etc.)
 
 with
 join_with_trade_events as (
@@ -20,8 +21,8 @@ join_with_trade_events as (
         block_number as placement_block,
         evt_block_number as fill_block,
         order_uid
-    from cow_protocol_ethereum.eth_flow_orders
-    left outer join gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade
+    from cow_protocol_{{network}}.eth_flow_orders
+    left outer join gnosis_protocol_v2_{{network}}.GPv2Settlement_evt_Trade
         on
             order_uid = orderUid
             and evt_block_time > block_time
@@ -35,8 +36,8 @@ cancellations as (
         evt_block_time as cancellation_time,
         evt_block_number as cancellation_block,
         sum(cast(value as double) / pow(10, 18)) as refund_amount_eth
-    from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderInvalidation
-    inner join ethereum.tracess
+    from cow_protocol_{{network}}.CoWSwapEthFlow_evt_OrderInvalidation
+    inner join {{network}}.traces
         on
             evt_block_number = block_number
             and evt_tx_hash = tx_hash
@@ -52,8 +53,8 @@ refunds as (
         refunder,
         orderUid,
         sum(cast(value as double) / pow(10, 18)) as refund_amount_eth
-    from cow_protocol_ethereum.CoWSwapEthFlow_evt_OrderRefund
-    inner join ethereum.traces
+    from cow_protocol_{{network}}.CoWSwapEthFlow_evt_OrderRefund
+    inner join {{network}}.traces
         on
             evt_block_number = block_number
             and evt_tx_hash = tx_hash


### PR DESCRIPTION
Adds an optional variable, which we can configure in infra to exclude certain app codes from this alert. This is useful for integrations which are knowingly broken (e.g. infinex, even after trying to reach out multiple times) and which are causing unactionable alerts in our production channel.

## Test Plan

[Query](https://dune.com/queries/4904398?grace_period=10&network=base&start_time=2025-05-21+16%3A00%3A08.602970&end_time=2025-05-21+17%3A00%3A08.602970&category=third_party_data&catalog=dune&schema=cowprotocol&id=dune.cowprotocol.result_cow_protocol_ethereum_app_data&end_time_d83555=2025-05-21+17%3A00%3A08.602970&grace_period_n26d66=10&network_e15077=base&start_time_d83555=2025-05-21+16%3A00%3A08.602970&ignored_app_codes_t6c1ea=%27OneKey+CowSwap%27) ignoring an otherwise non refunded partner.