### PR TITLE
Adapt payouts query to work for multiple winners

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_auctions_from_rewards_query_4842868.sql
+++ b/cowprotocol/accounting/rewards/excluded_auctions_from_rewards_query_4842868.sql
@@ -35,6 +35,7 @@ base_march_4_11_auctions_final as (
 ------------------------------
 
 select
-    bd.tx_hash,
+    bd.environment,
+    bd.auction_id,
     ea.multiplier
 from base_march_4_11_auctions_final as ea inner join "query_4351957(blockchain='{{blockchain}}')" as bd on ea.environment = bd.environment and ea.auction_id = bd.auction_id

--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -92,8 +92,8 @@ order_quotes as (
         quote_solver
     from "query_4364122(blockchain='{{blockchain}}')"
     where
-        block_deadline >= (select start_block from block_range)
-        and block_deadline <= (select end_block from block_range)
+        coalesce(block_deadline, block_number) >= (select start_block from block_range)
+        and coalesce(block_deadline, block_number) <= (select end_block from block_range)
 ),
 
 winning_quotes as (

--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -16,31 +16,29 @@ named_results as (
 ),
 
 -- BEGIN SOLVER REWARDS
-batch_rewards as (
+auction_data as (
     select
+        environment,
+        auction_id,
         solver,
-        network_fee,
-        execution_cost,
-        --rnr.capped_payment,
-        case
-            when uncapped_payment_native_token > {{upper_cap}} * pow(10, 18) then {{upper_cap}} * (pow(10, 18))
-            when uncapped_payment_native_token < {{lower_cap}} * pow(10, 18) then {{lower_cap}} * pow(10, 18)
-            else uncapped_payment_native_token
-        end as capped_payment,
-        tx_hash
-    from "query_4351957(blockchain='{{blockchain}}')"
+        total_network_fee,
+        total_execution_cost,
+        capped_payment
+    from "query_5270914(blockchain='{{blockchain}}')"
     where
         block_deadline >= (select start_block from block_range)
         and block_deadline <= (select end_block from block_range)
 ),
 
-batch_rewards_filtered as (
+auction_data_filtered as (
     select
-        br.solver,
-        br.network_fee,
-        br.execution_cost,
-        br.capped_payment * coalesce(ea.multiplier, 1) as capped_payment
-    from batch_rewards as br left outer join "query_4842868(blockchain='{{blockchain}}')" as ea on br.tx_hash = ea.tx_hash
+        ad.environment,
+        ad.auction_id,
+        ad.solver,
+        ad.total_network_fee,
+        ad.total_execution_cost,
+        ad.capped_payment * coalesce(ea.multiplier, 1) as capped_payment
+    from auction_data as ad left outer join "query_4842868(blockchain='{{blockchain}}')" as ea on ad.environment = ea.envirment and ad.auction_id = ea.auction_id
 ),
 
 -- AKA Performance Rewards
@@ -48,16 +46,16 @@ primary_rewards as (
     select
         solver,
         cast(sum(capped_payment) as double) as reward_wei
-    from batch_rewards_filtered
+    from auction_data_filtered
     group by solver
 ),
 
 fees_and_costs as (
     select
         solver,
-        cast(sum(network_fee) as double) as network_fee_wei,
-        cast(sum(execution_cost) as double) as execution_cost_wei
-    from batch_rewards_filtered
+        cast(sum(total_network_fee) as double) as network_fee_wei,
+        cast(sum(total_execution_cost) as double) as execution_cost_wei
+    from auction_data_filtered
     group by solver
 ),
 
@@ -94,8 +92,8 @@ order_quotes as (
         quote_solver
     from "query_4364122(blockchain='{{blockchain}}')"
     where
-        block_number >= (select start_block from block_range)
-        and block_number <= (select end_block from block_range)
+        block_deadline >= (select start_block from block_range)
+        and block_deadline <= (select end_block from block_range)
 ),
 
 winning_quotes as (


### PR DESCRIPTION
This PR adapts the main payouts query (id = 2510345) to work for multiple winners. It uses the recently introduced [raw_auction_data query ](https://dune.com/queries/5270914) and for quote rewards, it assumes that in the raw_order_data, the block_deadline is provided. As this column is currently missing from the raw_order_data query, and the easiest way out would be to backfill with null, it falls back to using block_number whenever the deadline is missing, thus making it consistent with the payouts as they have been executed up till today.