### PR TITLE
Exclude flashloans tx from slippage accounting

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -220,6 +220,10 @@ where
     or tx_hash = 0xac8de01cd4f8737c95bf66d451ce8d2eda31802a41c9629e4c4557e943e13edc
     or tx_hash = 0xf886919e66f466b7381c4c939e131038a745990357ae9d77ad073668ebb08238
 
+    -- for week of June 10 - June 17, 2025 on Mainnet
+    or tx_hash = 0x0183756d30137630a9c1f7c02c9ec904751147e0fedbd7e529f31d05aac04baf
+    -- due to bug with slippage accounting for flashloans txs
+
 -- Base
 union all
 select distinct tx_hash


### PR DESCRIPTION
This is a PR to exclude this tx from slippage accounting
https://etherscan.io/tx/0x0183756d30137630a9c1f7c02c9ec904751147e0fedbd7e529f31d05aac04baf

There is nothing wrong with the tx itself, but there is a bug in how we do slippage accounting for flashloans txs (As they have a redundant transfer from the settlement contract to itself that messes with the accounting).

A proper fix needs to be applied asap.