### PR TITLE
Remove deprecated bonding pools

### DIFF
--- a/cowprotocol/accounting/rewards/full_bonding_pools_query_4056263.sql
+++ b/cowprotocol/accounting/rewards/full_bonding_pools_query_4056263.sql
@@ -2,21 +2,23 @@
 --  are currently valid at CoW Protocol.
 with
 full_bonding_pools as (
-    select
-        from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address, -- deprecated
-        'Gnosis' as pool_name,
-        from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as creator
-    union distinct
+    -- deprecated
+    -- select
+    --     from_hex('0x8353713b6D2F728Ed763a04B886B16aAD2b16eBD') as pool_address,
+    --     'Gnosis' as pool_name,
+    --     from_hex('0x6c642cafcbd9d8383250bb25f67ae409147f78b2') as creator
+    -- union distinct
     select
         from_hex('0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6') as pool_address,
         'CoW DAO' as pool_name,
         from_hex('0x423cec87f19f0778f549846e0801ee267a917935') as creator
     union distinct
-    select
-        from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address, -- deprecated
-        'Project Blanc' as pool_name,
-        from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as creator
-    union distinct
+    -- deprecated
+    -- select
+    --     from_hex('0xC96569Dc132ebB6694A5f0b781B33f202Da8AcE8') as pool_address,
+    --     'Project Blanc' as pool_name,
+    --     from_hex('0xCa99e3Fc7B51167eaC363a3Af8C9A185852D1622') as creator
+    -- union distinct
     select
         from_hex('0x7489f267C3b43dc76e4cb190F7B55ab3297706AF') as pool_address,
         'Gnosis DAO' as pool_name,

--- a/cowprotocol/accounting/rewards/reduced_bonding_pools_query_4065709.sql
+++ b/cowprotocol/accounting/rewards/reduced_bonding_pools_query_4065709.sql
@@ -18,54 +18,57 @@ reduced_bonding_pools as (
         from_hex('0xA6A871b612bCE899b1CbBad6E545e5e47Da98b87') as solver_address,
         timestamp '2024-08-21 07:15:00' as creation_date
     union distinct
-    select
-        'prod-Copium_Capital' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'ethereum' as blockchain,
-        from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool_address,
-        from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver_address,
-        timestamp '2024-07-25 07:42:00' as creation_date
-    union distinct
-    select
-        'prod-Copium_Capital' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'gnosis' as blockchain,
-        from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool_address,
-        from_hex('0xfaBBDf8a77005C00edBe0000bDC000644c024322') as solver_address,
-        timestamp '2024-07-25 07:42:00' as creation_date
-    union distinct
-    select
-        'prod-Rizzolver' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'ethereum' as blockchain,
-        from_hex('0x0Deb0Ae9c4399C51289adB1f3ED83557A56dF657') as pool_address,
-        from_hex('0x9DFc9Bb0FfF2dc96728D2bb94eaCee6ba3592351') as solver_address,
-        timestamp '2024-10-10 02:03:00' as creation_date
-    union distinct
-    select
-        'barn-Rizzolver' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'ethereum' as blockchain,
-        from_hex('0x0deb0ae9c4399c51289adb1f3ed83557a56df657') as pool_address,
-        from_hex('0x26B5e3bF135D3Dd05A220508dD61f25BF1A47cBD') as solver_address,
-        timestamp '2024-10-10 02:03:00' as creation_date
-    union distinct
-    select
-        'prod-Rizzolver' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'arbitrum' as blockchain,
-        from_hex('0x0Deb0Ae9c4399C51289adB1f3ED83557A56dF657') as pool_address,
-        from_hex('0x23e868881dfe0531358B8FE0cbec43FD860cbF33') as solver_address,
-        timestamp '2024-10-10 02:03:00' as creation_date
-    union distinct
-    select
-        'barn-Rizzolver' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'arbitrum' as blockchain,
-        from_hex('0x0deb0ae9c4399c51289adb1f3ed83557a56df657') as pool_address,
-        from_hex('0x26B5e3bF135D3Dd05A220508dD61f25BF1A47cBD') as solver_address,
-        timestamp '2024-10-10 02:03:00' as creation_date
-    union distinct
+    -- deprecated
+    -- select
+    --     'prod-Copium_Capital' as solver_name,
+    --     'Reduced-CoW-DAO' as pool_name,
+    --     'ethereum' as blockchain,
+    --     from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool_address,
+    --     from_hex('0x008300082C3000009e63680088f8c7f4D3ff2E87') as solver_address,
+    --     timestamp '2024-07-25 07:42:00' as creation_date
+    -- union distinct
+    -- select
+    --     'prod-Copium_Capital' as solver_name,
+    --     'Reduced-CoW-DAO' as pool_name,
+    --     'gnosis' as blockchain,
+    --     from_hex('0xc5Dc06423f2dB1B11611509A5814dD1b242268dd') as pool_address,
+    --     from_hex('0xfaBBDf8a77005C00edBe0000bDC000644c024322') as solver_address,
+    --     timestamp '2024-07-25 07:42:00' as creation_date
+    -- union distinct
+
+    -- deprecated
+    -- select
+    --     'prod-Rizzolver' as solver_name,
+    --     'Reduced-CoW-DAO' as pool_name,
+    --     'ethereum' as blockchain,
+    --     from_hex('0x0Deb0Ae9c4399C51289adB1f3ED83557A56dF657') as pool_address,
+    --     from_hex('0x9DFc9Bb0FfF2dc96728D2bb94eaCee6ba3592351') as solver_address,
+    --     timestamp '2024-10-10 02:03:00' as creation_date
+    -- union distinct
+    -- select
+    --     'barn-Rizzolver' as solver_name,
+    --     'Reduced-CoW-DAO' as pool_name,
+    --     'ethereum' as blockchain,
+    --     from_hex('0x0deb0ae9c4399c51289adb1f3ed83557a56df657') as pool_address,
+    --     from_hex('0x26B5e3bF135D3Dd05A220508dD61f25BF1A47cBD') as solver_address,
+    --     timestamp '2024-10-10 02:03:00' as creation_date
+    -- union distinct
+    -- select
+    --     'prod-Rizzolver' as solver_name,
+    --     'Reduced-CoW-DAO' as pool_name,
+    --     'arbitrum' as blockchain,
+    --     from_hex('0x0Deb0Ae9c4399C51289adB1f3ED83557A56dF657') as pool_address,
+    --     from_hex('0x23e868881dfe0531358B8FE0cbec43FD860cbF33') as solver_address,
+    --     timestamp '2024-10-10 02:03:00' as creation_date
+    -- union distinct
+    -- select
+    --     'barn-Rizzolver' as solver_name,
+    --     'Reduced-CoW-DAO' as pool_name,
+    --     'arbitrum' as blockchain,
+    --     from_hex('0x0deb0ae9c4399c51289adb1f3ed83557a56df657') as pool_address,
+    --     from_hex('0x26B5e3bF135D3Dd05A220508dD61f25BF1A47cBD') as solver_address,
+    --     timestamp '2024-10-10 02:03:00' as creation_date
+    -- union distinct
     select
         'prod-Portus' as solver_name,
         'Reduced-CoW-DAO' as pool_name,
@@ -81,22 +84,22 @@ reduced_bonding_pools as (
         from_hex('0x3075F6aab29D92F8F062A83A0318c52c16E69a60') as pool_address,
         from_hex('0x5131590ca2E9D3edC182581352b289dcaE83430c') as solver_address,
         timestamp '2024-10-21 03:33:00' as creation_date
-    union distinct
-    select
-        'prod-Fractal' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'ethereum' as blockchain,
-        from_hex('0xDdb0a7BeBF71Fb5d3D7FB9B9B0804beDdf9C1C88') as pool_address,
-        from_hex('0x95480d3f27658e73b2785d30beb0c847d78294c7') as solver_address,
-        timestamp '2024-10-29 11:57:00' as creation_date
-    union distinct
-    select
-        'barn-Fractal' as solver_name,
-        'Reduced-CoW-DAO' as pool_name,
-        'ethereum' as blockchain,
-        from_hex('0xDdb0a7BeBF71Fb5d3D7FB9B9B0804beDdf9C1C88') as pool_address,
-        from_hex('0x2a2883ade8ce179265f12fc7b48a4b50b092f1fd') as solver_address,
-        timestamp '2024-10-29 11:57:00' as creation_date
+-- deprecated
+-- select
+--     'prod-Fractal' as solver_name,
+--     'Reduced-CoW-DAO' as pool_name,
+--     'ethereum' as blockchain,
+--     from_hex('0xDdb0a7BeBF71Fb5d3D7FB9B9B0804beDdf9C1C88') as pool_address,
+--     from_hex('0x95480d3f27658e73b2785d30beb0c847d78294c7') as solver_address,
+--     timestamp '2024-10-29 11:57:00' as creation_date
+-- union distinct
+-- select
+--     'barn-Fractal' as solver_name,
+--     'Reduced-CoW-DAO' as pool_name,
+--     'ethereum' as blockchain,
+--     from_hex('0xDdb0a7BeBF71Fb5d3D7FB9B9B0804beDdf9C1C88') as pool_address,
+--     from_hex('0x2a2883ade8ce179265f12fc7b48a4b50b092f1fd') as solver_address,
+--     timestamp '2024-10-29 11:57:00' as creation_date
 )
 
 select *


### PR DESCRIPTION
This PR removes bonding pools that are not valid anymore from the relevant dune queries, so as to reduce the possibility of side effects in the accounting pipeline