### PR TITLE
Exclude tx from slippage for June 17-24, 2025

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -220,9 +220,12 @@ where
     or tx_hash = 0xac8de01cd4f8737c95bf66d451ce8d2eda31802a41c9629e4c4557e943e13edc
     or tx_hash = 0xf886919e66f466b7381c4c939e131038a745990357ae9d77ad073668ebb08238
 
-    -- for week of June 10 - June 17, 2025 on Mainnet
+    -- for week of June 10 - June 17, 2025 on mainnet
     or tx_hash = 0x0183756d30137630a9c1f7c02c9ec904751147e0fedbd7e529f31d05aac04baf
     -- due to bug with slippage accounting for flashloans txs
+
+    -- for week of June 17 - June 2024, 2025 on mainnet
+    or tx_hash = 0x939879ff06f5c9e94d3e27f3b78cbcbb8eae72782a5fdcac831c743e2a5492e1
 
 -- Base
 union all


### PR DESCRIPTION
This PR removes this tx
https://etherscan.io/tx/0x939879ff06f5c9e94d3e27f3b78cbcbb8eae72782a5fdcac831c743e2a5492e1

from slippage accounting as Dune has a wrong price for the sell token (and the solver trades the fee so as to collect it in the buy token, thus messing up with the accounting).

One can run this query
```
select * from cow_protocol_ethereum.trades
where sell_token_address = 0xC91a71A1fFA3d8B22ba615BA1B9c01b2BBBf55ad or buy_token_address = 0xC91a71A1fFA3d8B22ba615BA1B9c01b2BBBf55ad
```

to verify that no other transaction involving this token took place during this accounting period.

Attaching a picture that shows the wrong price
![image](https://github.com/user-attachments/assets/64d63dcd-8937-4bcd-8525-4a677f8d2fd2)
