### PR TITLE
Fix bug in rewards query

### DIFF
--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -29,7 +29,7 @@ auction_data as (
         ad.total_network_fee,
         ad.total_execution_cost,
         ad.capped_payment
-    from "query_5270914(blockchain='{{blockchain}}')" as ad
+    from "query_5270914(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}')" as ad
     inner join auction_range on ad.environment = auction_range.environment
     where ad.auction_id >= auction_range.min_auction_id and ad.auction_id <= auction_range.max_auction_id
 ),


### PR DESCRIPTION
This PR fixes a small bug introduced in the main rewards query where some parameters were not passed when invoking the auction data query.

Fix has already been applied in the query: https://dune.com/queries/2510345