### PR TITLE
Exclude tx from slippage

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -226,7 +226,6 @@ where
 
     -- for week of June 17 - June 2024, 2025 on mainnet
     or tx_hash = 0x939879ff06f5c9e94d3e27f3b78cbcbb8eae72782a5fdcac831c743e2a5492e1
-    
     -- for the week of June 24 - June 30, 2025 on mainnet
     or tx_hash = 0xC60E65F001E2CEDE1A2399FBF40E049B7F7BD57D8A982DE66EF4E44C23967589
 

--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -226,6 +226,9 @@ where
 
     -- for week of June 17 - June 2024, 2025 on mainnet
     or tx_hash = 0x939879ff06f5c9e94d3e27f3b78cbcbb8eae72782a5fdcac831c743e2a5492e1
+    
+    -- for the week of June 24 - June 30, 2025 on mainnet
+    or tx_hash = 0xC60E65F001E2CEDE1A2399FBF40E049B7F7BD57D8A982DE66EF4E44C23967589
 
 -- Base
 union all

--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -226,6 +226,7 @@ where
 
     -- for week of June 17 - June 2024, 2025 on mainnet
     or tx_hash = 0x939879ff06f5c9e94d3e27f3b78cbcbb8eae72782a5fdcac831c743e2a5492e1
+
     -- for the week of June 24 - June 30, 2025 on mainnet
     or tx_hash = 0xC60E65F001E2CEDE1A2399FBF40E049B7F7BD57D8A982DE66EF4E44C23967589
 


### PR DESCRIPTION
This PR updates the excluded_batches_query to exclude this tx from the slippage:
https://app.blocksec.com/explorer/tx/eth/0xC60E65F001E2CEDE1A2399FBF40E049B7F7BD57D8A982DE66EF4E44C23967589

This is listed on Dune as having a slippage of -8172 usd.