### PR TITLE
added blocks data to use partitioning in tx

### DIFF
--- a/cowprotocol/accounting/rewards/auction_data_5270914.sql
+++ b/cowprotocol/accounting/rewards/auction_data_5270914.sql
@@ -29,7 +29,11 @@ txs_block_range as (
 ),
 
 block_data as (
-select first_block, min_block.date min_block_date, last_block, max_block.date as max_block_date
+select 
+tx.first_block,
+min_block.date min_block_date,
+tx.last_block,
+max_block.date as max_block_date
 from txs_block_range tx
 inner join {{blockchain}}.blocks max_block
 on tx.last_block = max_block.number

--- a/cowprotocol/accounting/rewards/auction_data_5270914.sql
+++ b/cowprotocol/accounting/rewards/auction_data_5270914.sql
@@ -29,16 +29,16 @@ txs_block_range as (
 ),
 
 block_data as (
-select 
-tx.first_block,
-min_block.date min_block_date,
-tx.last_block,
-max_block.date as max_block_date
-from txs_block_range tx
-inner join {{blockchain}}.blocks max_block
-on tx.last_block = max_block.number
-inner join {{blockchain}}.blocks min_block
-on tx.last_block = min_block.number
+    select 
+        tx.first_block,
+        min_block.date min_block_date,
+        tx.last_block,
+        max_block.date as max_block_date
+    from txs_block_range tx
+    inner join {{blockchain}}.blocks max_block
+    on tx.last_block = max_block.number
+    inner join {{blockchain}}.blocks min_block
+    on tx.last_block = min_block.number
 ),
 
 -- the following table is a restriction of the transactions table, with the goal to speed up subsequent computations

--- a/cowprotocol/accounting/rewards/auction_data_5270914.sql
+++ b/cowprotocol/accounting/rewards/auction_data_5270914.sql
@@ -28,11 +28,21 @@ txs_block_range as (
     where block_deadline >= (select start_block from block_range) and block_deadline <= (select end_block from block_range)
 ),
 
+block_data as (
+select first_block, min_block.date min_block_date, last_block, max_block.date as max_block_date
+from txs_block_range tx
+inner join {{blockchain}}.blocks max_block
+on tx.last_block = max_block.number
+inner join {{blockchain}}.blocks min_block
+on tx.last_block = min_block.number
+),
+
 -- the following table is a restriction of the transactions table, with the goal to speed up subsequent computations
 candidate_txs as (
     select *
     from {{blockchain}}.transactions
-    where block_number >= (select first_block from txs_block_range) and block_number <= (select last_block from txs_block_range)
+    where block_date >= (select min_block_date from block_data) and block_date <= (select max_block_date from block_data)
+    and block_number >= (select first_block from txs_block_range) and block_number <= (select last_block from txs_block_range)
 ),
 
 relevant_txs as (

--- a/cowprotocol/accounting/rewards/auction_data_5270914.sql
+++ b/cowprotocol/accounting/rewards/auction_data_5270914.sql
@@ -35,17 +35,18 @@ block_data as (
         tx.last_block,
         max_block.date as max_block_date
     from txs_block_range as tx
-        inner join {{blockchain}}.blocks as max_block
-            on tx.last_block = max_block.number
-        inner join {{blockchain}}.blocks as min_block
-            on tx.last_block = min_block.number
+    inner join {{blockchain}}.blocks as max_block
+        on tx.last_block = max_block.number
+    inner join {{blockchain}}.blocks as min_block
+        on tx.last_block = min_block.number
 ),
 
 -- the following table is a restriction of the transactions table, with the goal to speed up subsequent computations
 candidate_txs as (
     select *
     from {{blockchain}}.transactions
-    where block_date >= (select min_block_date from block_data) and block_date <= (select max_block_date from block_data)
+    where
+        block_date >= (select min_block_date from block_data) and block_date <= (select max_block_date from block_data)
         and block_number >= (select first_block from txs_block_range) and block_number <= (select last_block from txs_block_range)
 ),
 

--- a/cowprotocol/accounting/rewards/auction_data_5270914.sql
+++ b/cowprotocol/accounting/rewards/auction_data_5270914.sql
@@ -29,16 +29,16 @@ txs_block_range as (
 ),
 
 block_data as (
-    select 
+    select
         tx.first_block,
-        min_block.date min_block_date,
+        min_block.date as min_block_date,
         tx.last_block,
         max_block.date as max_block_date
-    from txs_block_range tx
-    inner join {{blockchain}}.blocks max_block
-    on tx.last_block = max_block.number
-    inner join {{blockchain}}.blocks min_block
-    on tx.last_block = min_block.number
+    from txs_block_range as tx
+        inner join {{blockchain}}.blocks as max_block
+            on tx.last_block = max_block.number
+        inner join {{blockchain}}.blocks as min_block
+            on tx.last_block = min_block.number
 ),
 
 -- the following table is a restriction of the transactions table, with the goal to speed up subsequent computations
@@ -46,7 +46,7 @@ candidate_txs as (
     select *
     from {{blockchain}}.transactions
     where block_date >= (select min_block_date from block_data) and block_date <= (select max_block_date from block_data)
-    and block_number >= (select first_block from txs_block_range) and block_number <= (select last_block from txs_block_range)
+        and block_number >= (select first_block from txs_block_range) and block_number <= (select last_block from txs_block_range)
 ),
 
 relevant_txs as (


### PR DESCRIPTION
While filtering on transactions, we should try to involve block_date whenever we can. This is because the transactions (logs,traces) tables are partitioned on block_date and it helps avoid looking into the full table if we add it in the filter