### PR TITLE
Update slippage query for current pipeline

### DIFF
--- a/cowprotocol/accounting/slippage/.sqlfluff
+++ b/cowprotocol/accounting/slippage/.sqlfluff
@@ -3,4 +3,4 @@ start_time='2024-08-01 12:00'
 end_time='2024-08-02 12:00'
 blockchain='ethereum'
 slippage_table_name=slippage_per_solver,slippage_per_transaction
-raw_slippage_table_name=raw_slippage_breakdown,raw_slippage_per_transaction
+raw_slippage_table_name=raw_slippage_breakdown,raw_slippage_breakdown_grouped,raw_slippage_per_transaction

--- a/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
+++ b/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
@@ -109,21 +109,17 @@ raw_slippage_breakdown as (
 ),
 
 raw_slippage_breakdown_grouped as (
-select 
-    block_time, 
-    tx_hash, 
-    token_address, 
-    slippage_type, 
-    sum(slippage_atoms) as slippage_atoms,
-    sum(slippage_usd) as slippage_usd,
-    sum(slippage_wei) as slippage_wei
-from raw_slippage_breakdown
-where token_address is not null
-group by     
-    block_time, 
-    tx_hash, 
-    token_address, 
-    slippage_type
+    select
+        block_time,
+        tx_hash,
+        token_address,
+        slippage_type,
+        sum(slippage_atoms) as slippage_atoms,
+        sum(slippage_usd) as slippage_usd,
+        sum(slippage_wei) as slippage_wei
+    from raw_slippage_breakdown
+    where token_address is not null
+    group by 1, 2, 3, 4
 ),
 
 raw_slippage_per_transaction as (


### PR DESCRIPTION
This PR adds a change to the raw splippage query to produce an output compatible with our data pipeline.

That changed version is already used in production via [this query](https://dune.com/queries/5143874). This PR allows for switching our pipeline to use the query under version control.

If significant changes are required to the query, they should be done in a follow up PR.

## Context

The reason for the change is that the incremental strategy used in our accounting requires a unique key. Without the grouping, the combination of columns `(tx_hash, token_address, slippage_type)` is not unique. With this change it is.

The problem is that in principle there can be identical rows in the breakdown. The grouping forces it to become unique, without much interference with the rest of the code.

One piece of information which is lost with this approach is multiple protocol fees on the same token.

## Testing

The proposed change is already used in production.