### PR TITLE
Change buffer accouting price feed to hourly price feed

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -28,19 +28,18 @@ with token_times as (
 -- Precise prices are prices from the Dune price feed.
 precise_prices as (
     select -- noqa: ST06
-        date_trunc('hour', minute) as hour, --noqa: RF04
+        "timestamp" as hour, --noqa: RF04
         token_address,
         decimals,
-        avg(price) as price_unit,
-        avg(price) / pow(10, decimals) as price_atom
+        price as price_unit,
+        price / pow(10, decimals) as price_atom
     from
-        prices.usd
+        prices.hour
     inner join token_times
         on
-            date_trunc('hour', minute) = hour
+            "timestamp" = hour
             and contract_address = token_address
             and blockchain = '{{blockchain}}'
-    group by 1, 2, 3
 ),
 
 -- Intrinsic prices are prices reconstructed from exchange rates from within the auction
@@ -140,17 +139,16 @@ wrapped_native_token as (
 -- The price of the native token is reconstructed from it chain-dependent wrapped version.
 native_token_prices as (
     select -- noqa: ST06
-        date_trunc('hour', minute) as hour, --noqa: RF04
+        "timestamp" as hour, --noqa: RF04
         0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee as token_address,
         18 as decimals,
-        avg(price) as price_unit,
-        avg(price) / pow(10, 18) as price_atom
-    from prices.usd
+        price as price_unit,
+        price / pow(10, 18) as price_atom
+    from prices.hour
     where
         blockchain = '{{blockchain}}'
         and contract_address = (select native_token_address from wrapped_native_token)
-        and minute >= cast('{{start_time}}' as timestamp) and minute < cast('{{end_time}}' as timestamp)
-    group by 1, 2, 3
+        and "timestamp" >= cast('{{start_time}}' as timestamp) and "timestamp" < cast('{{end_time}}' as timestamp)
 )
 
 select * from prices


### PR DESCRIPTION
This PR addresses #210.

A test query for raw slippage is [here](https://dune.com/queries/5517876?end_time_d83555=2025-07-22+00%3A00%3A00&start_time_d83555=2025-07-15+00%3A00%3A00).

One can check that for [this](https://etherscan.io/tx/0x71AEA9D790FAE3539CD45D0A01D3B8651C5A4C5CEAAADF1E224F7A2C86F2794A) and [that](https://etherscan.io/tx/0x2F7B5C5942103F781C57022816B74F19069CF8546F26373E6CC227972DA75D48) transaction excluded in #215 the price feed produces results consistent with the execution of the settlement.

I tested run times for raw slippage and the old query took 2 minutes while the new query took 4 minutes.