### PR TITLE
Add conversion prices query

### DIFF
--- a/cowprotocol/accounting/rewards/conversion_prices_5533118.sql
+++ b/cowprotocol/accounting/rewards/conversion_prices_5533118.sql
@@ -21,12 +21,12 @@ native_token_prices as (
         avg(price) as native_token_price
     from prices.usd
     where (
-        blockchain = 'ethereum' and contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 or
-        blockchain = 'gnosis' and contract_address = 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d or
-        blockchain = 'arbitrum' and contract_address = 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 or
-        blockchain = 'base' and contract_address = 0x4200000000000000000000000000000000000006 or
-        blockchain = 'avalanche_c' and contract_address = 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 or
-        blockchain = 'polygon' and contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270
+        blockchain = 'ethereum' and contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        or blockchain = 'gnosis' and contract_address = 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d
+        or blockchain = 'arbitrum' and contract_address = 0x82af49447d8a07e3bd95bd0d56f35241523fbab1
+        or blockchain = 'base' and contract_address = 0x4200000000000000000000000000000000000006
+        or blockchain = 'avalanche_c' and contract_address = 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7
+        or blockchain = 'polygon' and contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270
     )
     group by 1, 2, 3
 )

--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -65,30 +65,13 @@ fees_and_costs as (
 
 conversion_prices as (
     select
-        (
-            select avg(price) from prices.usd
-            where
-                blockchain = 'ethereum' -- use cow price from mainnet
-                and contract_address = 0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab
-                and date(minute) = cast('{{end_time}}' as timestamp) - interval '1' day
-        ) as cow_price,
-        (
-            select avg(price) from prices.usd
-            where
-                blockchain = '{{blockchain}}' -- use native prices from respective chains
-                and contract_address = (
-                    select
-                        case
-                            when '{{blockchain}}' = 'ethereum' then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-                            when '{{blockchain}}' = 'gnosis' then 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d
-                            when '{{blockchain}}' = 'arbitrum' then 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1
-                            when '{{blockchain}}' = 'base' then 0x4200000000000000000000000000000000000006
-                            when '{{blockchain}}' = 'avalanche_c' then 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7
-                            when '{{blockchain}}' = 'polygon' then 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270
-                        end
-                )
-                and date(minute) = cast('{{end_time}}' as timestamp) - interval '1' day
-        ) as native_token_price
+        cow_price,
+        native_token_price
+    from dune.cowprotocol.result_accounting_cow_and_native_prices_per_chain
+    where
+        blockchain = '{{blockchain}}'
+        and end_time > date_add('day', -1, cast('{{end_time}}' as timestamp))
+        and end_time < date_add('day', +1, cast('{{end_time}}' as timestamp))
 ),
 
 -- BEGIN QUOTE REWARDS


### PR DESCRIPTION
This PR introduces a materialized conversion prices query that precomputes the conversion prices (COW/native token) used in the weekly accounting. This is meant to speed up the main solver rewards query.

New query: https://dune.com/queries/5533118

Schedule: materialize on Tuesdays at 4am.

Test query: https://dune.com/queries/5544153

Note: i noticed test query might return non-empty results, but only the very last decimal might differ, so this must be due to rounding differences

<img width="712" height="271" alt="image" src="https://github.com/user-attachments/assets/4ce9475a-4306-433c-bd3a-b7c7126ff669" />


