### PR TITLE
Remove the exclude auctions from rewards subquery from main rewards query

### DIFF
--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -34,23 +34,23 @@ auction_data as (
     where ad.auction_id >= auction_range.min_auction_id and ad.auction_id <= auction_range.max_auction_id
 ),
 
-auction_data_filtered as (
-    select
-        ad.environment,
-        ad.auction_id,
-        ad.solver,
-        ad.total_network_fee,
-        ad.total_execution_cost,
-        ad.capped_payment * coalesce(ea.multiplier, 1) as capped_payment
-    from auction_data as ad left outer join "query_4842868(blockchain='{{blockchain}}')" as ea on ad.environment = ea.environment and ad.auction_id = ea.auction_id
-),
+-- auction_data_filtered as (
+--     select
+--         ad.environment,
+--         ad.auction_id,
+--         ad.solver,
+--         ad.total_network_fee,
+--         ad.total_execution_cost,
+--         ad.capped_payment * coalesce(ea.multiplier, 1) as capped_payment
+--     from auction_data as ad left outer join "query_4842868(blockchain='{{blockchain}}')" as ea on ad.environment = ea.environment and ad.auction_id = ea.auction_id
+-- ),
 
 -- AKA Performance Rewards
 primary_rewards as (
     select
         solver,
         cast(sum(capped_payment) as double) as reward_wei
-    from auction_data_filtered
+    from auction_data
     group by solver
 ),
 
@@ -59,7 +59,7 @@ fees_and_costs as (
         solver,
         cast(sum(total_network_fee) as double) as network_fee_wei,
         cast(sum(total_execution_cost) as double) as execution_cost_wei
-    from auction_data_filtered
+    from auction_data
     group by solver
 ),
 


### PR DESCRIPTION
In an attempt to finally get the main solver rewards dashboard to work again (which i thought i had with PR #221 but it seems it doesn't work), i propose to remove the subquery that is meant to exclude certain auction ids from rewards.

This was only used once when the issue with buy order surplus showed up. If it shows up again, we can always add it back, but for now it doesn't serve anything and only slows down the query.