### PR TITLE
Update .sqlfluff

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,4 +1,21 @@
 [sqlfluff]
-dialect = ansi
-exclude_rules = L046, RF02, RF06, CP02, ST10, LT14, RF05, CV10
-max_line_length = 0
+dialect = trino
+templater = jinja
+max_line_length = 200
+rules = AL01,AL02,AL03,AL04,AL08,AM01,AM02,AM08,CP01,CP02,CP03,CP04,CP05,CV12,LT02,LT07,LT09,LT10,LT13,RF03,ST04,JJ01
+
+[sqlfluff:rules:capitalisation.keywords] 
+capitalisation_policy = lower
+
+[sqlfluff:indentation] # See https://docs.sqlfluff.com/en/stable/perma/indent_locations.html
+indent_unit = space
+tab_space_size = 4
+indented_on_contents = False
+
+[sqlfluff:templater:jinja:context] # unfortunately every parameter used in queries must be defined here - the value does not matter.
+blockchain = 'ethereum'
+starttime = '2023-01-01'
+endtime = '2024-01-01'
+period = 'last 3m'
+date_granularity = 'month'
+aggregate_by = 'month'


### PR DESCRIPTION
Updating the sqlfluff rules to be enforced. This configuration will apply to all files in this directory unless --config is used in the sqlfluff lint command. Also note that parameters must be defined here in order to pass linting, apparently there's no way to avoid this.