### PR TITLE
[MEVBlocker] limit max bundle size

### DIFF
--- a/mevblocker/fees/value_per_tx_4188777.sql
+++ b/mevblocker/fees/value_per_tx_4188777.sql
@@ -37,6 +37,9 @@ mev_blocker_filtered AS (
         blocknumber >= (SELECT start_block FROM block_range)
         AND blocknumber < (SELECT end_block FROM block_range)
         AND COALESCE(referrer, 'No referrer') LIKE '{{referrer}}'
+        AND transactions IS NOT NULL
+        AND TRY(JSON_PARSE(transactions)) IS NOT NULL
+        AND JSON_SIZE(JSON_PARSE(transactions), '$') < 10  -- exclude megabundles
 ),
 
 -- perfomance optimisation: relevant ethereum transactions during that timeframe


### PR DESCRIPTION
This PR backports some of the changes that we done to the original query around preprocessing the transaction list of the bundles that are considered for the fee.

It replaces the existing length check of the transaction field (based on total characters) with a length check of the actual number of transactions in the parsed object.

A too large of a number there is causing overflow issues with Dune's execution.

### Test Plan

https://dune.com/queries/4188777?end_d83555=2025-08-01+00%3A00%3A00&start_d83555=2025-07-01+00%3A00%3A00