### PR TITLE
Add prices to mainnet price feed for August 29 - Sep2, 2025 accounting

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -37,9 +37,9 @@ precise_prices as (
         prices.usd
     inner join token_times
         on
-            date_trunc('hour', minute) = hour
-            and contract_address = token_address
-            and blockchain = '{{blockchain}}'
+        date_trunc('hour', minute) = hour
+        and contract_address = token_address
+        and blockchain = '{{blockchain}}'
     group by 1, 2, 3
 ),
 
@@ -101,12 +101,12 @@ prices_pre as (
     from token_times as tt
     left join precise_prices as precise
         on
-            tt.hour = precise.hour
-            and tt.token_address = precise.token_address
+        tt.hour = precise.hour
+        and tt.token_address = precise.token_address
     left join intrinsic_prices as intrinsic
         on
-            tt.hour = intrinsic.hour
-            and tt.token_address = intrinsic.token_address
+        tt.hour = intrinsic.hour
+        and tt.token_address = intrinsic.token_address
 ),
 
 prices as (

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -116,10 +116,14 @@ prices as (
         decimals,
         case
             when '{{blockchain}}' = 'base' and token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8 and hour >= timestamp '2025-08-31 03:00' and hour <= timestamp '2025-08-31 04:00' then 4459.365
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 5254.7182
             else price_unit
         end as price_unit,
         case
             when '{{blockchain}}' = 'base' and token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585 / pow(10, 18)
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8 and hour >= timestamp '2025-08-31 03:00' and hour <= timestamp '2025-08-31 04:00' then 4459.365 / pow(10, 18)
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 5254.7182
             else price_atom
         end as price_atom
     from prices_pre

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -123,7 +123,7 @@ prices as (
         case
             when '{{blockchain}}' = 'base' and token_address = 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b and hour >= timestamp '2025-03-04 00:00' and hour <= timestamp '2025-03-11 00:00' then 0.00029585 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8 and hour >= timestamp '2025-08-31 03:00' and hour <= timestamp '2025-08-31 04:00' then 4459.365 / pow(10, 18)
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 5254.7182
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 5254.7182 / pow(10,18)
             else price_atom
         end as price_atom
     from prices_pre


### PR DESCRIPTION
It was flagged that these 2 txs don't show any slippage on Dune, due to missing prices.

https://etherscan.io/tx/0x9cab916a0766d8a2b3f235f29766923d51b50a58f44ef5c4d6a2cbeba669e600

https://etherscan.io/tx/0x31a5fa7e29c644563ef583d641d851b1689780882c107b4799b5a4a1fb0f3a35

One can verify this by looking at this query:
https://dune.com/queries/4059683?end_time_d83555=2025-09-02+00%3A00%3A00&raw_slippage_table_name_e15077=raw_slippage_per_transaction&start_time_d83555=2025-08-26+00%3A00%3A00

and filtering by tx hash

The reason for this is due to missing prices of the buy tokens in the relevant hour time window when each tx took place, which can be verified here:
https://dune.com/queries/4064601?blockchain_t6c1ea=ethereum&end_time_d83555=2025-09-02+00:00:00&start_time_d83555=2025-08-26+00:00:00

To fix this, we looked at the relevant auctions
- https://api.cow.fi/mainnet/api/v2/solver_competition/by_tx_hash/0x9cab916a0766d8a2b3f235f29766923d51b50a58f44ef5c4d6a2cbeba669e600
- https://api.cow.fi/mainnet/api/v2/solver_competition/by_tx_hash/0x31a5fa7e29c644563ef583d641d851b1689780882c107b4799b5a4a1fb0f3a35

and computed the exchange rate between the buy token and WETH, and then used that exchange rate combined with the WETH price at the hour of each trade to get a USD value for each token.

Concretely,
- 0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8: exchange rate is 1 to WETH
- 0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8: exchange rate is `1208909705490099200 /10**18 = 1.2089097054900992`

The relevant prices follow from the above exchange rates and the prices shown in the screenshots below

<img width="1751" height="30" alt="image" src="https://github.com/user-attachments/assets/d99ef7ba-0cf2-492e-af5d-508468d74930" />
<img width="1769" height="33" alt="image" src="https://github.com/user-attachments/assets/01f7103f-0f1d-40d5-8ec4-a82e9f3ee8cd" />
