### PR TITLE
Exclude another mainnet tx from slippage for August 26 - Sep2, 2025

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -245,8 +245,9 @@ where
     or tx_hash = 0x71aea9d790fae3539cd45d0a01d3b8651c5a4c5ceaaadf1e224f7a2c86f2794a
     or tx_hash = 0x2f7b5c5942103f781c57022816b74f19069cf8546f26373e6cc227972da75d48
 
-    -- for the week of August 29 - Sept 2, 2025 on mainnet
+    -- for the week of August 26 - Sept 2, 2025 on mainnet
     or tx_hash = 0x5c550c99a39a7315a699d6e5c6592038f26f7d93b787cf63312e38a72df17e2a
+    or tx_hash = 0xbd68462f2d22340ed4e2818b0fac68f9ab78afe07e9ed6e73f72cbde0c40735f
 
 -- Base
 union all


### PR DESCRIPTION
Bogus prices resulting in very large positive slippage

https://app.blocksec.com/explorer/tx/eth/0xBD68462F2D22340ED4E2818B0FAC68F9AB78AFE07E9ED6E73F72CBDE0C40735F

<img width="996" height="94" alt="image" src="https://github.com/user-attachments/assets/dbb5460c-63bf-44ba-94c7-ab50fed0c9e8" />
