### PR TITLE
Fix date format in lp token base query

### DIFF
--- a/cowamm/profitability/lp_prices/amm_lp_table_4781568.sql
+++ b/cowamm/profitability/lp_prices/amm_lp_table_4781568.sql
@@ -5,37 +5,37 @@
 with cow_amms as (
     select
         'ethereum' as blockchain, t.*
-    from "query_4420687(blockchain = 'ethereum', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420687(blockchain = 'ethereum', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
     union all
     select
         'gnosis' as blockchain, t.*
-    from "query_4420687(blockchain = 'gnosis', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420687(blockchain = 'gnosis', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
     union all
     select
         'arbitrum' as blockchain, t.*
-    from "query_4420687(blockchain = 'arbitrum', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420687(blockchain = 'arbitrum', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
     union all
     select
         'base' as blockchain, t.*
-    from "query_4420687(blockchain = 'base', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420687(blockchain = 'base', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
 ),
 
 uni_style_pools as (
     select
         'ethereum' as blockchain, t.*
-    from "query_4420675(blockchain = 'ethereum', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420675(blockchain = 'ethereum', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
     union all
     select
         'gnosis' as blockchain, t.*
-    from "query_4420675(blockchain = 'gnosis', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420675(blockchain = 'gnosis', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
     union all
     select
         'arbitrum' as blockchain, t.*
-    from "query_4420675(blockchain = 'arbitrum', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420675(blockchain = 'arbitrum', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
     union all
     select
         'base' as blockchain, t.*
-    from "query_4420675(blockchain = 'base', start = '2024-07-29', end = '2100-01-01')" as t
+    from "query_4420675(blockchain = 'base', start = '2024-07-29 00:00:00', end = '2100-01-01 00:00:00')" as t
 )
 
 select


### PR DESCRIPTION
Some CoW AMM query had been failing for some time due to issues with parsing strings into timestamps.

There might have been an internal change on Dune to not allow parsing a string of the form `'2024-07-29'` into a date parameter. I changed the string to `'2024-07-29 00:00:00'` and that seems to work.

This change is already used in the query on Dune. This PR just reflects the change on the side of the dune-queries repo.