### PR TITLE
Adapt price feed in slippage accounting for Aave tokens

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -25,21 +25,49 @@ with token_times as (
     group by 1, 2
 ),
 
+aave_tokens_mapping as (
+    select distinct
+        chain as blockchain,
+        atoken as atoken_address,
+        asset as underlying_address
+    from aave_v3_multichain.poolconfigurator_evt_reserveinitialized
+    union distinct
+    select distinct
+        'ethereum' as blockchain,
+        atoken as atoken_address,
+        asset as underlying_address
+    from aave_v3_lido_ethereum.poolconfigurator_evt_reserveinitialized
+    union distinct
+    select distinct
+        'ethereum' as blockchain,
+        atoken as atoken_address,
+        asset as underlying_address
+    from aave_v3_ethereum.etherfipoolconfiguratorinstance_evt_reserveinitialized
+),
+
+token_times_enriched as (
+    select
+        tt.token_address,
+        coalesce(atm.underlying_address, tt.token_address) as proxy_address,
+        tt.hour
+    from token_times as tt left join aave_tokens_mapping as atm
+        on tt.token_address = atm.atoken_address
+    where atm.blockchain = '{{blockchain}}'
+),
+
 -- Precise prices are prices from the Dune price feed.
 precise_prices as (
     select -- noqa: ST06
-        date_trunc('hour', minute) as hour, --noqa: RF04
-        token_address,
-        decimals,
-        avg(price) as price_unit,
-        avg(price) / pow(10, decimals) as price_atom
-    from
-        prices.usd
-    inner join token_times
+        date_trunc('hour', p.minute) as hour, --noqa: RF04
+        tte.token_address,
+        p.decimals,
+        avg(p.price) as price_unit,
+        avg(p.price) / pow(10, p.decimals) as price_atom
+    from token_times_enriched as tte inner join prices.usd as p
         on
-        date_trunc('hour', minute) = hour
-        and contract_address = token_address
-        and blockchain = '{{blockchain}}'
+        date_trunc('hour', p.minute) = tte.hour
+        and p.contract_address = tte.proxy_address
+        and p.blockchain = '{{blockchain}}'
     group by 1, 2, 3
 ),
 

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -51,8 +51,7 @@ token_times_enriched as (
         coalesce(atm.underlying_address, tt.token_address) as proxy_address,
         tt.hour
     from token_times as tt left join aave_tokens_mapping as atm
-        on tt.token_address = atm.atoken_address
-    where atm.blockchain = '{{blockchain}}'
+        on tt.token_address = atm.atoken_address and atm.blockchain = '{{blockchain}}'
 ),
 
 -- Precise prices are prices from the Dune price feed.

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -46,6 +46,7 @@ aave_tokens_mapping as (
 ),
 
 token_times_enriched as (
+    -- All tokens are associated with a proxy address which is used for finding a price feed instead of the original contract address
     select
         tt.token_address,
         coalesce(atm.underlying_address, tt.token_address) as proxy_address,

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -56,15 +56,15 @@ token_times_enriched as (
 
 -- Precise prices are prices from the Dune price feed.
 precise_prices as (
-    select -- noqa: ST06
-        date_trunc('hour', p.minute) as hour, --noqa: RF04
+    select
+        tte.hour,
         tte.token_address,
         p.decimals,
         avg(p.price) as price_unit,
         avg(p.price) / pow(10, p.decimals) as price_atom
     from token_times_enriched as tte inner join prices.usd as p
         on
-        date_trunc('hour', p.minute) = tte.hour
+        tte.hour = date_trunc('hour', p.minute)
         and p.contract_address = tte.proxy_address
         and p.blockchain = '{{blockchain}}'
     group by 1, 2, 3


### PR DESCRIPTION
As the `prices.usd` Dune table is not working great with Aave tokens, this query uses a mapping of these tokens to the underlying asset in order to use the address of the underlying asset for recovering the price of the token itself.

The mapping is done using this cte

```
aave_tokens_mapping as (
    select distinct
        chain as blockchain,
        atoken as atoken_address,
        asset as underlying_address
    from aave_v3_multichain.poolconfigurator_evt_reserveinitialized
    union distinct
    select distinct
        'ethereum' as blockchain,
        atoken as atoken_address,
        asset as underlying_address
    from aave_v3_lido_ethereum.poolconfigurator_evt_reserveinitialized
    union distinct
    select distinct
        'ethereum' as blockchain,
        atoken as atoken_address,
        asset as underlying_address
    from aave_v3_ethereum.etherfipoolconfiguratorinstance_evt_reserveinitialized
),
```

Modified query can be tested here: https://dune.com/queries/5749995