### PR TITLE
Add price for Base tx

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -172,6 +172,7 @@ wrapped_native_token as (
             when 'base' then 0x4200000000000000000000000000000000000006 -- WETH
             when 'avalanche_c' then 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- WAVAX
             when 'polygon' then 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WPOL
+            when 'lens' then 0x6bdc36e20d267ff0dd6097799f82e78907105e2f -- WGHO
         end as native_token_address
 ),
 

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -148,6 +148,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x23878914efe38d27c4d67ab83ed1b93a74d4086a and hour >= timestamp '2025-08-31 03:00' and hour <= timestamp '2025-08-31 04:00' then 0.9983
             when '{{blockchain}}' = 'ethereum' and token_address = 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 5254.7182
             when '{{blockchain}}' = 'ethereum' and token_address = 0x23878914efe38d27c4d67ab83ed1b93a74d4086a and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 0.9983
+            when '{{blockchain}}' = 'base' and token_address = 0x2e285de4c868d225949dbdaf82cd5e28497c52bf and hour >= timestamp '2025-09-23 15:00' and hour <= timestamp '2025-09-23 16:00' then 0.003
             else price_unit
         end as price_unit,
         case
@@ -156,6 +157,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x23878914efe38d27c4d67ab83ed1b93a74d4086a and hour >= timestamp '2025-08-31 03:00' and hour <= timestamp '2025-08-31 04:00' then 0.9983 / pow(10, 6)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x0b925ed163218f6662a35e0f0371ac234f9e9371 and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 5254.7182 / pow(10,18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x23878914efe38d27c4d67ab83ed1b93a74d4086a and hour >= timestamp '2025-08-29 19:00' and hour <= timestamp '2025-08-29 20:00' then 0.9983 / pow(10, 6)
+            when '{{blockchain}}' = 'base' and token_address = 0x2e285de4c868d225949dbdaf82cd5e28497c52bf and hour >= timestamp '2025-09-23 15:00' and hour <= timestamp '2025-09-23 16:00' then 0.003 / pow(10, 18)
             else price_atom
         end as price_atom
     from prices_pre
@@ -170,7 +172,6 @@ wrapped_native_token as (
             when 'base' then 0x4200000000000000000000000000000000000006 -- WETH
             when 'avalanche_c' then 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- WAVAX
             when 'polygon' then 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WPOL
-            when 'lens' then 0x6bdc36e20d267ff0dd6097799f82e78907105e2f -- WGHO
         end as native_token_address
 ),
 


### PR DESCRIPTION
This tx currently doesn't show up in the slippage accounting
https://basescan.org/tx/0xcd7e4084e5c06553637159745c66fd70e1123faa46d9cd6f00de3611635c8ec2

because the price of 0x2e285de4c868d225949dbdaf82cd5e28497c52bf is missing.

This PR adds an approximate price for this