### PR TITLE
Add base query for analysing CIP 74

### DIFF
--- a/cowprotocol/mechanism/cip_74_analysis/.sqlfluff
+++ b/cowprotocol/mechanism/cip_74_analysis/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff:templater:jinja:context]
+blockchain=ethereum
+start_time='2024-08-20 00:00:00'
+end_time='2024-08-27 00:00:00'
+volume_fee_bps_stable=2.0
+volume_fee_bps_variable=2.0

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -71,6 +71,7 @@ aggregated_batch_data as (
         rbd.auction_id,
         rbd.solver,
         rbd.uncapped_payment_native_token as uncapped_reward,
+        sum(rbd.winning_score) as score,
         coalesce(sum((rod.protocol_fee - coalesce(rod.partner_fee, 0)) * rod.protocol_fee_native_price), 0) as protocol_fee, -- this is the actual revenue of the protocol
         coalesce(sum(case when t.order_type = 'SELL' then t.atoms_bought * rod.protocol_fee_native_price else t.atoms_sold * rod.protocol_fee_native_price end), 0) as volume,
         bool_and(
@@ -109,6 +110,7 @@ rewards_per_auction as (
         protocol_fee,
         volume,
         protocol_fee + volume * (if(xrate_type = 'stable', {{volume_fee_bps_stable}}, {{volume_fee_bps_variable}}) - 2.0) / 1e4 as new_protocol_fee,
+        score,
         uncapped_reward
     from aggregated_batch_data
     where

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -13,9 +13,9 @@
 -- - time: time of the auction (deadline)
 -- - auction_id: id of the auction
 -- - solver: winning solver in that auction
--- - xrate_type: either 'stable' for a trades between highly correlated tokens, 'variable' for trades between uncorrelated tokens,
+-- - xrate_type: either 'stable' for trades between highly correlated tokens, 'variable' for trades between uncorrelated tokens,
 --     None if a classification was not possible
--- - protocol_fee: sum of protocol fees charged by a solver, in native token
+-- - protocol_fee: sum of protocol fees (excluding fees charged by partners) charged by a solver, in native token
 -- - volume: sum of volume of trades, in native token
 -- - new_protocol_fee: new protocol fee when changing the volume fee for some class of orders
 -- - uncapped_reward: uncapped second price reward for the solver in that auction

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -1,0 +1,130 @@
+-- This query is the basis for experiments with capping rewards by a fraction of protocol fees
+--
+-- It is under version control in https://github.com/cowprotocol/dune-queries
+--
+-- Parameters:
+--  {{start_time}} - the timestamp for which the analysis should start (inclusively)
+--  {{end_time}} - the timestamp for which the analysis should end (exclusively)
+--  {{blockchain}} - network to run the analysis on
+--  {{volume_fee_bps_stable}} - fraction of volume charged as fee on correlated tokens
+--  {{volume_fee_bps_variable}} - fraction of volume charged as fee on uncorrelated tokens
+--
+-- The columns of the result are
+-- - time: time of the auction (deadline)
+-- - auction_id: id of the auction
+-- - solver: winning solver in that auction
+-- - xrate_type: either 'stable' for a trades between highly correlated tokens, 'variable' for trades between uncorrelated tokens,
+--     None if a classification was not possible
+-- - protocol_fee: sum of protocol fees charged by a solver, in native token
+-- - volume: sum of volume of trades, in native token
+-- - new_protocol_fee: new protocol fee when changing the volume fee for some class of orders
+-- - uncapped_reward: uncapped second price reward for the solver in that auction
+-- - reward: current reward
+-- - new_reward: reward based on capping from above by new_protocol_fee, the original cap from below applies
+-- - old_reward: reward based on static caps
+-- - profit: protocol profit as difference of protocol fee and reward
+-- - new_profit: same as profit but for new reward and new protocol fee
+-- - reward_missed: amount a solver could have gotten from taking a cut instead of getting a capped reward;
+--     this is a measure of how much solvers can gain from acting strategically with their bidding
+-- - new_reward_missed: same as reward_missed but for new reward
+-- - old_reward_missed: same as reward_missed but for old reward
+
+
+with wrapped_native_token as (
+    select
+        case '{{blockchain}}'
+            when 'ethereum' then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
+            -- when 'gnosis' then 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d -- WXDAI
+            when 'arbitrum' then 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 -- WETH
+            when 'base' then 0x4200000000000000000000000000000000000006 -- WETH
+            -- when 'avalanche_c' then 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- WAVAX
+            -- when 'polygon' then 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WPOL
+            -- when 'lens' then 0x6bdc36e20d267ff0dd6097799f82e78907105e2f -- WGHO
+        end as native_token_address
+),
+
+reward_caps as (
+    select
+        case '{{blockchain}}'
+            when 'ethereum' then 12000000000000000 -- 0.012 ETH
+            when 'arbitrum' then 12000000000000000 -- 0.012 ETH
+            when 'base' then 12000000000000000 -- 0.012 ETH
+        end as upper_cap,
+        case '{{blockchain}}'
+            when 'ethereum' then 10000000000000000 -- 0.01 ETH
+            when 'arbitrum' then 10000000000000000 -- 0.01 ETH
+            when 'base' then 10000000000000000 -- 0.01 ETH
+        end as lower_cap
+),
+
+aggregated_batch_data as (
+    select
+        b.time,
+        rbd.auction_id,
+        rbd.solver,
+        rbd.uncapped_payment_native_token as uncapped_reward,
+        coalesce(sum((rod.protocol_fee - coalesce(rod.partner_fee, 0)) * rod.protocol_fee_native_price), 0) as protocol_fee, -- this is the actual revenue of the protocol
+        coalesce(sum(case when t.order_type = 'SELL' then t.atoms_bought * rod.protocol_fee_native_price else t.atoms_sold * rod.protocol_fee_native_price end), 0) as volume,
+        bool_and(
+            case
+                when t.order_type = 'SELL' then abs((rod.protocol_fee_native_price * t.atoms_bought * p.price / 1e18) / coalesce(t.buy_value_usd, t.usd_value) - 1) < 0.2
+                else abs((rod.protocol_fee_native_price  * t.atoms_sold * p.price / 1e18) / coalesce(t.sell_value_usd, t.usd_value) - 1) < 0.2
+            end
+        ) as native_prices_are_accurate,
+        bool_or(t.tx_hash is not null) as at_least_partial_success, -- this implies that there is data on trades which makes checking native prices meaningful
+        if(bool_and(st.ref_date is not null), 'stable', if(bool_and(t.sell_token_address is not null and st.ref_date is null), 'variable')) as xrate_type
+    from "query_4351957(blockchain='{{blockchain}}')" as rbd
+    left join "query_4364122(blockchain='{{blockchain}}')" as rod
+        on rbd.auction_id = rod.auction_id and rbd.solver = rod.solver and rbd.tx_hash = rod.tx_hash
+    left join cow_protocol_{{blockchain}}.trades as t
+        on rod.order_uid = t.order_uid and rod.tx_hash = t.tx_hash
+    left join {{blockchain}}.blocks as b
+        on rbd.block_deadline = b.number
+    left join prices.day as p
+        on date_trunc('day', b.time) = p.timestamp
+        and p.contract_address = (select * from wrapped_native_token)
+        and p.blockchain = '{{blockchain}}'
+    left join "query_5719467(blockchain='{{blockchain}}', start_date='{{start_time}}', end_date='{{end_time}}')" as st
+        on t.sell_token_address = st.sell_token_address
+        and t.buy_token_address = st.buy_token_address
+        and t.block_date = date(st.ref_date)
+    where b.time >= (timestamp '{{start_time}}') and b.time < (timestamp '{{end_time}}')
+    group by 1, 2, 3, 4
+),
+
+rewards_per_auction as (
+    select
+        time,
+        auction_id,
+        solver,
+        xrate_type,
+        protocol_fee,
+        volume,
+        protocol_fee + volume * (if(xrate_type = 'stable', {{volume_fee_bps_stable}}, {{volume_fee_bps_variable}}) - 2.0) / 1e4 as new_protocol_fee,
+        uncapped_reward
+    from aggregated_batch_data
+    where
+        (
+            native_prices_are_accurate -- this filters out cases where native prices are not accurate
+            and abs(uncapped_reward) < volume -- this filters out cases where native prices were corrected but rewards are too large
+        )
+        or not at_least_partial_success -- this makes sure the filtering is only applied if some onchain data exists
+),
+
+new_rewards_per_auction as (
+    select
+        *,
+        least(protocol_fee, greatest(uncapped_reward, -(select lower_cap from reward_caps))) as reward,
+        least(new_protocol_fee, greatest(uncapped_reward, -(select lower_cap from reward_caps))) as new_reward,
+        least((select upper_cap from reward_caps), greatest(uncapped_reward, -(select lower_cap from reward_caps))) as old_reward
+    from rewards_per_auction
+)
+
+select
+    *,
+    protocol_fee - reward as profit,
+    new_protocol_fee - new_reward as new_profit,
+    if(uncapped_reward >=0, uncapped_reward - reward, 0) as reward_missed,
+    if(uncapped_reward >=0, uncapped_reward - new_reward, 0) as new_reward_missed,
+    if(uncapped_reward >=0, uncapped_reward - old_reward, 0) as old_reward_missed
+from new_rewards_per_auction

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -46,26 +46,26 @@ with wrapped_native_token as (
 reward_caps as (
     select
         case '{{blockchain}}'
-            when 'ethereum' then 12000000000000000 -- 0.012 ETH
-            when 'arbitrum' then 12000000000000000 -- 0.012 ETH
-            when 'base' then 12000000000000000 -- 0.012 ETH
-            when 'gnosis' then 10 * 1e18
-            when 'avalanche_c' then 0.4 * 1e18
-            when 'polygon' then 40 * 1e18
-            when 'bnb' then 0.048 * 1e18 
+            when 'ethereum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
+            when 'arbitrum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
+            when 'base' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
+            when 'gnosis' then cast(10 * 1e18 as int256) -- 10 xDAI
+            when 'avalanche_c' then cast(0.4 * 1e18 as int256) -- 0.4 AVAX
+            when 'polygon' then cast(40 * 1e18 as int256) -- 40 POL
+            when 'bnb' then cast(0.048 * 1e18 as int256)  -- 0.048 BNB
         end as upper_cap,
         case '{{blockchain}}'
-            when 'ethereum' then 10000000000000000 -- 0.01 ETH
-            when 'arbitrum' then 10000000000000000 -- 0.01 ETH
-            when 'base' then 10000000000000000 -- 0.01 ETH
-            when 'gnosis' then 10 * 1e18
-            when 'avalanche_c' then 0.3 * 1e18
-            when 'polygon' then 30 * 1e18
-            when 'bnb' then 0.04 * 1e18
+            when 'ethereum' then cast(0.01 * 1e18 as int256) -- 0.01 ETH
+            when 'arbitrum' then cast(0.01 * 1e18 as int256) -- 0.01 ETH
+            when 'base' then cast(0.01 * 1e18 as int256) -- 0.01 ETH
+            when 'gnosis' then cast(10 * 1e18 as int256) -- 10 xDAI
+            when 'avalanche_c' then cast(0.3 * 1e18 as int256) -- 0.3 AVAX
+            when 'polygon' then cast(30 * 1e18 as int256) -- 30 POL
+            when 'bnb' then cast(0.04 * 1e18 as int256)  -- 0.04 BNB
         end as lower_cap
 ),
 
-aggregated_batch_data as (
+per_solver_auction_data as (
     select
         b.time,
         rbd.auction_id,
@@ -112,7 +112,7 @@ rewards_per_auction as (
         protocol_fee + volume * (if(xrate_type = 'stable', {{volume_fee_bps_stable}}, {{volume_fee_bps_variable}}) - 2.0) / 1e4 as new_protocol_fee,
         score,
         uncapped_reward
-    from aggregated_batch_data
+    from per_solver_auction_data
     where
         (
             native_prices_are_accurate -- this filters out cases where native prices are not accurate

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -45,7 +45,7 @@ with wrapped_native_token as (
 
 reward_caps as (
     select
-        case '{{blockchain}}'
+        case '{{blockchain}}' --noqa: PRS, LT02
             when 'ethereum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
             when 'arbitrum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
             when 'base' then cast(0.012 * 1e18 as int256) -- 0.012 ETH

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -34,12 +34,12 @@ with wrapped_native_token as (
     select
         case '{{blockchain}}'
             when 'ethereum' then 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
-            -- when 'gnosis' then 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d -- WXDAI
+            when 'gnosis' then 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d -- WXDAI
             when 'arbitrum' then 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 -- WETH
             when 'base' then 0x4200000000000000000000000000000000000006 -- WETH
-            -- when 'avalanche_c' then 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- WAVAX
-            -- when 'polygon' then 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WPOL
-            -- when 'lens' then 0x6bdc36e20d267ff0dd6097799f82e78907105e2f -- WGHO
+            when 'avalanche_c' then 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- WAVAX
+            when 'polygon' then 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WPOL
+            when 'bnb' then 0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c -- WBNB
         end as native_token_address
 ),
 
@@ -49,11 +49,19 @@ reward_caps as (
             when 'ethereum' then 12000000000000000 -- 0.012 ETH
             when 'arbitrum' then 12000000000000000 -- 0.012 ETH
             when 'base' then 12000000000000000 -- 0.012 ETH
+            when 'gnosis' then 10 * 1e18
+            when 'avalanche_c' then 0.4 * 1e18
+            when 'polygon' then 40 * 1e18
+            when 'bnb' then 0.048 * 1e18 
         end as upper_cap,
         case '{{blockchain}}'
             when 'ethereum' then 10000000000000000 -- 0.01 ETH
             when 'arbitrum' then 10000000000000000 -- 0.01 ETH
             when 'base' then 10000000000000000 -- 0.01 ETH
+            when 'gnosis' then 10 * 1e18
+            when 'avalanche_c' then 0.3 * 1e18
+            when 'polygon' then 30 * 1e18
+            when 'bnb' then 0.04 * 1e18
         end as lower_cap
 ),
 

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -46,7 +46,7 @@ with wrapped_native_token as (
 
 reward_caps as (
     select
-        case '{{blockchain}}'
+        case '{{blockchain}}' --noqa: PRS, LT02
             when 'ethereum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
             when 'arbitrum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
             when 'base' then cast(0.012 * 1e18 as int256) -- 0.012 ETH

--- a/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
+++ b/cowprotocol/mechanism/cip_74_analysis/rewards_per_auction_6517101.sql
@@ -18,6 +18,7 @@
 -- - protocol_fee: sum of protocol fees (excluding fees charged by partners) charged by a solver, in native token
 -- - volume: sum of volume of trades, in native token
 -- - new_protocol_fee: new protocol fee when changing the volume fee for some class of orders
+-- - score: sum of winning scores, in native token
 -- - uncapped_reward: uncapped second price reward for the solver in that auction
 -- - reward: current reward
 -- - new_reward: reward based on capping from above by new_protocol_fee, the original cap from below applies
@@ -45,7 +46,7 @@ with wrapped_native_token as (
 
 reward_caps as (
     select
-        case '{{blockchain}}' --noqa: PRS, LT02
+        case '{{blockchain}}'
             when 'ethereum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
             when 'arbitrum' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
             when 'base' then cast(0.012 * 1e18 as int256) -- 0.012 ETH
@@ -71,8 +72,10 @@ per_solver_auction_data as (
         rbd.auction_id,
         rbd.solver,
         rbd.uncapped_payment_native_token as uncapped_reward,
+        rbd.capped_payment as reward,
         sum(rbd.winning_score) as score,
         coalesce(sum((rod.protocol_fee - coalesce(rod.partner_fee, 0)) * rod.protocol_fee_native_price), 0) as protocol_fee, -- this is the actual revenue of the protocol
+        coalesce(sum(coalesce(rod.protocol_volume_fee, 0) * rod.protocol_fee_native_price), 0) as protocol_volume_fee, 
         coalesce(sum(case when t.order_type = 'SELL' then t.atoms_bought * rod.protocol_fee_native_price else t.atoms_sold * rod.protocol_fee_native_price end), 0) as volume,
         bool_and(
             case
@@ -98,7 +101,7 @@ per_solver_auction_data as (
         and t.buy_token_address = st.buy_token_address
         and t.block_date = date(st.ref_date)
     where b.time >= (timestamp '{{start_time}}') and b.time < (timestamp '{{end_time}}')
-    group by 1, 2, 3, 4
+    group by 1, 2, 3, 4, 5
 ),
 
 rewards_per_auction as (
@@ -108,15 +111,17 @@ rewards_per_auction as (
         solver,
         xrate_type,
         protocol_fee,
+        protocol_volume_fee,
         volume,
-        protocol_fee + volume * (if(xrate_type = 'stable', {{volume_fee_bps_stable}}, {{volume_fee_bps_variable}}) - 2.0) / 1e4 as new_protocol_fee,
+        protocol_fee - protocol_volume_fee + (volume + protocol_volume_fee) * if(xrate_type = 'stable', {{volume_fee_bps_stable}}, {{volume_fee_bps_variable}}) / 1e4 as new_protocol_fee,
         score,
-        uncapped_reward
+        uncapped_reward,
+        reward
     from per_solver_auction_data
     where
         (
             native_prices_are_accurate -- this filters out cases where native prices are not accurate
-            and abs(uncapped_reward) < volume -- this filters out cases where native prices were corrected but rewards are too large
+            and uncapped_reward < volume -- this filters out cases where native prices were corrected but rewards are too large
         )
         or not at_least_partial_success -- this makes sure the filtering is only applied if some onchain data exists
 ),
@@ -124,7 +129,6 @@ rewards_per_auction as (
 new_rewards_per_auction as (
     select
         *,
-        least(protocol_fee, greatest(uncapped_reward, -(select lower_cap from reward_caps))) as reward,
         least(new_protocol_fee, greatest(uncapped_reward, -(select lower_cap from reward_caps))) as new_reward,
         least((select upper_cap from reward_caps), greatest(uncapped_reward, -(select lower_cap from reward_caps))) as old_reward
     from rewards_per_auction


### PR DESCRIPTION
This is a draft PR for adding a base query on analysing the impact of CIP 74 on solvers.

The goal of the query is provide data per auction and solver on current and alternative rewards (e.g. the old reward scheme before CIP-74, changed volume fees).

The query is based on `rewards_per_auction_5787562.sql`. Main changes are
* A new column `xrate_type` classifying batches into those containing only trades on token pairs with `'stable'` (i.e. stongly correlated) and `'variable'` exchange rate. It is based on query 5719467 (see also #317) and its use in query 6481803.
* A new protocol fee computed as `protocol_fee + volume * (if(xrate_type = 'stable', {{volume_fee_bps_stable}}, {{volume_fee_bps_variable}}) - 2.0) / 1e4`. It removes the 2 bps fee and adds a fee depending on the classification in `'stable'` and not `'stable'`.
* Capping parameters are hardcoded to allow for computing old rewards.
* Some parameters of the old query are removed (e.g. on fixed fees or price improvement).

One way to approach for checking the query is to look at the changes compared to the query it is based on via 
```
git diff --no-index --color ../../accounting/rewards/reward_capping_experiments/rewards_per_auction_5787562.sql rewards_per_auction_6517101.sql
```
(from the folder of the new file).