### PR TITLE
Adapt hooksqueries due to recent decoding issue

### DIFF
--- a/cowprotocol/alerts/hooks/failed_bridges_5552265.sql
+++ b/cowprotocol/alerts/hooks/failed_bridges_5552265.sql
@@ -22,14 +22,12 @@ with all_hooks as (
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='bnb')"        
-    /* linea and plasma are only partially available at the moment but should be done soon enough
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='linea')"        
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='plasma')"    
-    */
 )
 select * 
 from all_hooks

--- a/cowprotocol/alerts/hooks/multiple_hooks_5534352.sql
+++ b/cowprotocol/alerts/hooks/multiple_hooks_5534352.sql
@@ -1,3 +1,4 @@
+--noqa: disable=all
 with 
 all_hooks as (
     select * 

--- a/cowprotocol/alerts/hooks/multiple_hooks_5534352.sql
+++ b/cowprotocol/alerts/hooks/multiple_hooks_5534352.sql
@@ -23,14 +23,12 @@ all_hooks as (
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='bnb')"        
-    /* linea and plasma are not fully ready yet but should be soon
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='linea')"        
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='plasma')"    
-    */
 )
 select *
 from (
@@ -38,8 +36,16 @@ from (
         *,
         count(1) over (partition by tx_hash, order_uid, hook_call_data, hook_target, hook_gas_limit) as hook_calls
     from all_hooks
-    where hook_app_id not in ('cow-swap://libs/hook-dapp-lib/permit', 'PERMIT_TOKEN','BUILD_CUSTOM_HOOK', '1db4bacb661a90fb6b475fd5b585acba9745bc373573c65ecc3e8f5bfd5dee1f')
+    where 
+        not(hook_app_id in (
+            'cow-swap://libs/hook-dapp-lib/permit', 
+            'PERMIT_TOKEN',
+            'BUILD_CUSTOM_HOOK',
+            '1db4bacb661a90fb6b475fd5b585acba9745bc373573c65ecc3e8f5bfd5dee1f',
+            'cow.fi')
+        )
+        and not(hook_app_id like 'cow-sdk://flashloans/aave%')
 )
-where
+where 
     hook_calls > 1
 order by block_time desc, order_uid

--- a/cowprotocol/alerts/hooks/skipped_hooks_5534339.sql
+++ b/cowprotocol/alerts/hooks/skipped_hooks_5534339.sql
@@ -1,3 +1,4 @@
+--noqa: disable=all
 with all_hooks as (    
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='ethereum')"

--- a/cowprotocol/alerts/hooks/skipped_hooks_5534339.sql
+++ b/cowprotocol/alerts/hooks/skipped_hooks_5534339.sql
@@ -22,17 +22,21 @@ with all_hooks as (
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='bnb')"        
-    /* linea and plasma are only partially available at the moment but should be done soon enough
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='linea')"        
     union all
     select * 
     from "query_5534333(lookback_time_unit='{{time_unit}}', lookback_units='{{units}}', blockchain='plasma')"    
-    */
 )
 select * 
 from all_hooks
 where 
-    hook_success is null 
-    and hook_app_id not in ('cow-swap://libs/hook-dapp-lib/permit', 'PERMIT_TOKEN', '1db4bacb661a90fb6b475fd5b585acba9745bc373573c65ecc3e8f5bfd5dee1f')
+    coalesce(hook_success,false) = false
+    and not( hook_app_id in (
+        'cow-swap://libs/hook-dapp-lib/permit',
+        'PERMIT_TOKEN',
+        '1db4bacb661a90fb6b475fd5b585acba9745bc373573c65ecc3e8f5bfd5dee1f',
+        'cow.fi')
+    )
+    and not(hook_app_id like 'cow-sdk://flashloans/aave%')


### PR DESCRIPTION
This addresses the recent encoding issue we found in app data and also filters out aave flashloans - this was causing false positives. Also included Plasma and Linea which were missing.