### PR TITLE
Exclude transaction from Base

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -308,6 +308,9 @@ where
     -- for week of March 18 - March 25, 2025 on Base
     or 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b in (buy_token_address) -- exclude BNKR
 
+    -- for week of March 10 - March 17, 2026 on Base
+    or tx_hash = 0x7FBFA52D0B86756A6C748A0BDE34E58B8CEC50C6EF46B260C42A7F8BAD3B98A1
+
 -- Arbitrum
 union all
 select distinct tx_hash


### PR DESCRIPTION
# Description
This PR excludes the following transaction from the Base payouts: https://explorer.cow.fi/base/tx/0x7FBFA52D0B86756A6C748A0BDE34E58B8CEC50C6EF46B260C42A7F8BAD3B98A1?tab=orders

# Context
Due to a bug one of the solvers erroneously filled a partially fillable order with the full amount, leading to an excessive surplus. Since this transaction occurred between two DAO safes no actual unusual slippage occurred so this PR will prevent us from deducting slippage from the solver's payouts.
