### PR TITLE
Update CI workflows to use commit hashes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # Necessary to get a complete history for diff
 
@@ -22,7 +22,7 @@ jobs:
           echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
 
       - name: Update Queries
-        uses: bh2smith/dune-update@v0.1.0
+        uses: bh2smith/dune-update@f22f6e55197fc8bd7b03e60b270229b58cca6f15
         with:
           changedQueries: ${{ steps.get-changed-files.outputs.changed_files }}
           duneApiKey: ${{ secrets.DUNE_API_KEY }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,15 +8,15 @@ jobs:
     name: SQLFluff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.9"
       - name: Install SQLFluff
         run: pip install sqlfluff
       - name: Get changed SQL files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           files: |
             **/*.sql
@@ -31,10 +31,10 @@ jobs:
   nitpicker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ethanis/nitpicker@v1
+      - uses: ethanis/nitpicker@e891622bbd9a6ec97a473bcfacfca7332caf2862 # v1.7
         with:
           nitpicks: ".github/nitpicks.yml"
           token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Description
This PR updates the GH workflows to use commit hashes for improved security in our workflows.