### PR TITLE
Exclude batches from slippage

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -314,6 +314,11 @@ where
     -- for week of March 18 - March 25, 2025 on Base
     or 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b in (buy_token_address) -- exclude BNKR
 
+    -- for the week of April 7 - April 14, 2026
+    or tx_hash = 0xDB22B4ED36F2ADBA7A9FA2AC5A3559FB4A8CDBEF18708B0BC5D580EB0526EA02
+    or tx_hash = 0xD1A0812C33C926E502C154FB96747D830F4CD03AAB45DFBE7FBA38403558B199
+	
+
 -- Arbitrum
 union all
 select distinct tx_hash


### PR DESCRIPTION
# Description
This PR excludes two batches from the slippage accounting for the week of April 7 to April 14, 2026

# Context
<img width="2242" height="723" alt="image" src="https://github.com/user-attachments/assets/21dd960d-f360-4ce0-9b26-f1c40b03dbfc" />
