### PR TITLE
Exclude BNB tx from slippage

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -338,6 +338,9 @@ where
     -- for week of Nov 11 - Nov 18, 2025 on BNB
     tx_hash = 0x193E147809099DE19B08EE6B7AAD699507C176AFACE8B47233473909BA948D1F
 
+    -- for week of April 07 - April 14, 2026 on BNB
+    tx_hash = 0xe3ccdb8c162b929fda198c04c2944f185bc02d5ffbc543044111cda3594b9a63
+
 -- GNOSIS
 union all
 select distinct tx_hash


### PR DESCRIPTION
# Description
This PR excludes a batch from the payouts for the week of April 7 to April 14, 2026 due to incorrect native prices for the DOT token.

# Context
<img width="1190" height="189" alt="image" src="https://github.com/user-attachments/assets/5b9641df-3f76-4b61-ab82-230b12d58e7b" />
