### PR TITLE
Add solver daily revert rate alert queries

### DIFF
--- a/cowprotocol/alerts/solver_daily_revert_rate_alert_7421251.sql
+++ b/cowprotocol/alerts/solver_daily_revert_rate_alert_7421251.sql
@@ -1,0 +1,59 @@
+select
+    'ethereum' as blockchain,
+    *
+from "query_6228775(blockchain='ethereum')"
+where percent_of_reverts > 40.0
+union all
+select
+    'gnosis' as blockchain,
+    *
+from "query_6228775(blockchain='gnosis')"
+where percent_of_reverts > 40.0
+union all
+select
+    'arbitrum' as blockchain,
+    *
+from "query_6228775(blockchain='arbitrum')"
+where percent_of_reverts > 40.0
+union all
+select
+    'base' as blockchain,
+    *
+from "query_6228775(blockchain='base')"
+where percent_of_reverts > 40.0
+union all
+select
+    'avalanche_c' as blockchain,
+    *
+from "query_6228775(blockchain='avalanche_c')"
+where percent_of_reverts > 40.0
+union all
+select
+    'polygon' as blockchain,
+    *
+from "query_6228775(blockchain='polygon')"
+where percent_of_reverts > 40.0
+union all
+select
+    'bnb' as blockchain,
+    *
+from "query_6228775(blockchain='bnb')"
+where percent_of_reverts > 40.0
+union all
+select
+    'linea' as blockchain,
+    *
+from "query_6228775(blockchain='linea')"
+where percent_of_reverts > 40.0
+union all
+select
+    'plasma' as blockchain,
+    *
+from "query_6228775(blockchain='plasma')"
+where percent_of_reverts > 40.0
+union all
+select
+    'ink' as blockchain,
+    *
+from "query_6228775(blockchain='ink')"
+where percent_of_reverts > 40.0

--- a/cowprotocol/alerts/solver_daily_revert_rate_base_query_6228775.sql
+++ b/cowprotocol/alerts/solver_daily_revert_rate_base_query_6228775.sql
@@ -1,0 +1,33 @@
+with batch_data as (
+    select
+        a.solver,
+        a.auction_id,
+        case
+            when a.tx_hash is null then 1
+            when a.block_number is not null and a.block_number > a.block_deadline then 1
+            else 0
+        end as is_revert,
+        b.time as deadline_timestamp
+    from "query_4351957(blockchain='{{blockchain}}')" as a inner join {{blockchain}}.blocks as b
+        on a.block_deadline = b.number
+    where
+        b.time >= now() - interval '1' day
+),
+
+breakdown_per_solver as (
+    select
+        solver,
+        sum(is_revert) as total_num_reverts,
+        count(*) as total_num_winning_solutions,
+        100 * sum(is_revert) * 1.0000 / count(*) as percent_of_reverts
+    from batch_data
+    group by solver
+)
+
+select
+    s.environment,
+    s.name,
+    a.*
+from breakdown_per_solver as a inner join cow_protocol_{{blockchain}}.solvers as s
+    on a.solver = s.address
+where a.total_num_winning_solutions > 20


### PR DESCRIPTION
This PR adds 2 queries that can be used to set a daily alert to track solvers with elevated revert rate

Base query: https://dune.com/queries/6228775
Alert query: https://dune.com/queries/7421251