### PR TITLE
switch to dbt solvers table

### DIFF
--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -133,7 +133,11 @@ aggregate_results as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 ),

--- a/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
+++ b/cowprotocol/accounting/rewards/main_rewards_dashboard_query_2510345.sql
@@ -132,6 +132,12 @@ aggregate_results as (
     from solver_competition_rewards as pr left outer join fees_and_costs as fc on pr.solver = fc.solver
 ),
 
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+),
+
 combined_data as (
     select
         coalesce(ar.solver, ss.solver, qr.solver) as solver,
@@ -154,7 +160,7 @@ combined_data as (
         on ar.solver = ss.solver
     full outer join quote_rewards as qr
         on ar.solver = qr.solver
-    left join cow_protocol_{{blockchain}}.solvers as s
+    left join solvers as s
         on coalesce(ar.solver, ss.solver, qr.solver) = s.address
 ),
 

--- a/cowprotocol/accounting/rewards/overdrafts_tracker_5936281.sql
+++ b/cowprotocol/accounting/rewards/overdrafts_tracker_5936281.sql
@@ -37,7 +37,11 @@ most_recent_updates as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/accounting/rewards/overdrafts_tracker_5936281.sql
+++ b/cowprotocol/accounting/rewards/overdrafts_tracker_5936281.sql
@@ -34,6 +34,12 @@ most_recent_updates as (
         from overdraft_update_events
     )
     where rn = 1
+),
+
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
 )
 
 select
@@ -43,6 +49,6 @@ select
     s.active,
     coalesce(mru.new_overdraft, 0) as current_ovedraft_native_token_atoms,
     coalesce(mru.new_overdraft, 0) / pow(10,18) as current_overdraft_native_token_units
-from cow_protocol_{{blockchain}}.solvers as s left join most_recent_updates as mru on s.address = mru.solver
+from solvers as s left join most_recent_updates as mru on s.address = mru.solver
 where coalesce(mru.new_overdraft, 0) > 0
 order by coalesce(mru.new_overdraft, 0) desc

--- a/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
@@ -20,7 +20,11 @@ url_helper as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
@@ -17,11 +17,17 @@ url_helper as (
             when '{{blockchain}}' = 'bnb' then 'bsc'
             else '{{blockchain}}'
         end
+),
+
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
 )
 
 select  --noqa: ST06
     rpt.block_time,
-    concat(environment, '-', name) as solver_name,
+    concat(s.environment, '-', s.name) as solver_name,
     concat(
         '<a href="https://dune.com/queries/4059683',
         '?blockchain={{blockchain}}',
@@ -47,7 +53,7 @@ select  --noqa: ST06
     network_fee_usd
 from results_per_tx as rpt
 inner join cow_protocol_{{blockchain}}.batches as b on rpt.tx_hash = b.tx_hash
-inner join cow_protocol_{{blockchain}}.solvers on address = rpt.solver_address
+inner join solvers as s on s.address = rpt.solver_address
 where (
     abs(slippage_usd) > {{min_absolute_slippage_tolerance}}
     and

--- a/cowprotocol/accounting/rewards/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/vouch_registry_query_1541516.sql
@@ -98,7 +98,11 @@ valid_vouches as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 ),

--- a/cowprotocol/accounting/rewards/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/vouch_registry_query_1541516.sql
@@ -97,6 +97,12 @@ valid_vouches as (
     where time_rank = 1
 ),
 
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+),
+
 named_results as (
     select
         vv.solver,
@@ -105,7 +111,7 @@ named_results as (
         bp.pool_name,
         concat(environment, '-', s.name) as solver_name
     from valid_vouches as vv
-    inner join cow_protocol_{{blockchain}}.solvers as s on vv.solver = s.address
+    inner join solvers as s on vv.solver = s.address
     inner join full_bonding_pools as bp on vv.pool_address = bp.pool_address
 )
 

--- a/cowprotocol/accounting/slippage/slippage_query_3427730.sql
+++ b/cowprotocol/accounting/slippage/slippage_query_3427730.sql
@@ -1,5 +1,9 @@
 with solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/accounting/slippage/slippage_query_3427730.sql
+++ b/cowprotocol/accounting/slippage/slippage_query_3427730.sql
@@ -1,3 +1,9 @@
+with solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+)
+
 select
     solver_address,
     concat(environment, '-', name) as solver_name,
@@ -12,5 +18,4 @@ select
         '" target="_blank">link</a>'
     ) as slippage_per_transaction
 from "query_4070065(blockchain='{{blockchain}}',start_time='{{start_time}}',end_time='{{end_time}}',slippage_table_name='slippage_per_solver')"
-inner join cow_protocol_{{blockchain}}.solvers
-    on solver_address = address
+inner join solvers as s on solver_address = s.address

--- a/cowprotocol/alerts/solver_daily_revert_rate_base_query_6228775.sql
+++ b/cowprotocol/alerts/solver_daily_revert_rate_base_query_6228775.sql
@@ -25,7 +25,11 @@ breakdown_per_solver as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/alerts/solver_daily_revert_rate_base_query_6228775.sql
+++ b/cowprotocol/alerts/solver_daily_revert_rate_base_query_6228775.sql
@@ -22,12 +22,17 @@ breakdown_per_solver as (
         100 * sum(is_revert) * 1.0000 / count(*) as percent_of_reverts
     from batch_data
     group by solver
+),
+
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
 )
 
 select
     s.environment,
     s.name,
     a.*
-from breakdown_per_solver as a inner join cow_protocol_{{blockchain}}.solvers as s
-    on a.solver = s.address
+from breakdown_per_solver as a inner join solvers as s on a.solver = s.address
 where a.total_num_winning_solutions > 20

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -1,5 +1,4 @@
-with
-ranked as (
+with ranked as (
     select
         evt_tx_hash as tx_hash,
         evt_block_time as block_time,
@@ -8,9 +7,15 @@ ranked as (
         contract_address as token,
         a.value,
         rank() over (partition by spender, contract_address order by evt_block_number desc, evt_index desc) as rk
-    from erc20_{{blockchain}}.evt_Approval as a
+    from erc20_{{blockchain}}.evt_approval as a
     inner join {{blockchain}}.transactions on evt_tx_hash = hash
-    where owner = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+    where owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
 )
 
 select --noqa: ST06
@@ -18,13 +23,13 @@ select --noqa: ST06
     tx_hash,
     responsible_address,
     case
-        when responsible_address = 0x05C5494572E4aB2d48D3AB3aAF6bD4e7b1c98382 or responsible_address = 0xd8ca5fe380b68171155c7069b8df166db28befdd then 'PROPOSER-ACCOUNT'
+        when responsible_address = 0x05c5494572e4ab2d48d3ab3aaf6bd4e7b1c98382 or responsible_address = 0xd8ca5fe380b68171155c7069b8df166db28befdd then 'PROPOSER-ACCOUNT'
         else coalesce(concat(environment, '-', name), 'NON-SOLVER')
     end as responsible_solver,
     spender,
     token,
     value
 from ranked as r
-left outer join cow_protocol_{{blockchain}}.solvers as s on r.responsible_address = s.address
+left outer join solvers as s on r.responsible_address = s.address
 where rk = 1 and value > 0
 order by block_time desc

--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -13,7 +13,11 @@ with ranked as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/revenue/daily_revenue_by_integration_per_chain_4515022.sql
+++ b/cowprotocol/revenue/daily_revenue_by_integration_per_chain_4515022.sql
@@ -3,11 +3,16 @@
 --  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
 --  {{blockchain}} - the chain for which to collect the data
 
+with solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+)
+
 select
     s.name,
     date(block_time) as "day",
     coalesce(sum("Limit"), 0) + coalesce(sum("Market"), 0) + coalesce(sum("UI Fee"), 0) + coalesce(sum("Partner Fee Share"), 0) as total
 from "query_4217030(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')" as r
-left join cow_protocol_{{blockchain}}.solvers as s
-    on r.solver = s.address
+left join solvers as s on r.solver = s.address
 group by 1, 2

--- a/cowprotocol/revenue/daily_revenue_by_integration_per_chain_4515022.sql
+++ b/cowprotocol/revenue/daily_revenue_by_integration_per_chain_4515022.sql
@@ -4,7 +4,11 @@
 --  {{blockchain}} - the chain for which to collect the data
 
 with solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/revenue/daily_revenue_by_solver_per_chain_4515000.sql
+++ b/cowprotocol/revenue/daily_revenue_by_solver_per_chain_4515000.sql
@@ -3,11 +3,16 @@
 --  {{ui_fee_recipient}} - the partner address that receives the CoW Swap UI fee
 --  {{blockchain}} - the chain for which to collect the data
 
+with solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+)
+
 select
     s.name,
     date(block_time) as "day",
     coalesce(sum("Limit"), 0) + coalesce(sum("Market"), 0) + coalesce(sum("UI Fee"), 0) + coalesce(sum("Partner Fee Share"), 0) as total
 from "query_4217030(blockchain='{{blockchain}}',ui_fee_recipient='{{ui_fee_recipient}}')" as r
-left join cow_protocol_{{blockchain}}.solvers as s
-    on r.solver = s.address
+left join solvers as s on r.solver = s.address
 group by 1, 2

--- a/cowprotocol/revenue/daily_revenue_by_solver_per_chain_4515000.sql
+++ b/cowprotocol/revenue/daily_revenue_by_solver_per_chain_4515000.sql
@@ -4,7 +4,11 @@
 --  {{blockchain}} - the chain for which to collect the data
 
 with solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/solver_dashboard/active_solvers_1372857.sql
+++ b/cowprotocol/solver_dashboard/active_solvers_1372857.sql
@@ -15,7 +15,11 @@ with solver_latest_batches as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 ),

--- a/cowprotocol/solver_dashboard/active_solvers_1372857.sql
+++ b/cowprotocol/solver_dashboard/active_solvers_1372857.sql
@@ -6,13 +6,18 @@
 -- Parameters
 -- {{blockchain}}: string the blockchain to query
 
-with
-solver_latest_batches as (
+with solver_latest_batches as (
     select
         solver_address,
         max(block_time) as latest_settlement
     from cow_protocol_{{blockchain}}.batches
     group by solver_address
+),
+
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
 ),
 
 active_solvers as (
@@ -21,12 +26,8 @@ active_solvers as (
         environment,
         name,
         coalesce(latest_settlement, timestamp '1970-01-01') as latest_settlement
-    from cow_protocol_{{blockchain}}.solvers
-    full outer join solver_latest_batches
-        on address = solver_address
-    where
-        environment not in ('test', 'service')
-        and active = true
+    from solvers full outer join solver_latest_batches on address = solver_address
+    where environment not in ('test', 'service') and active = true
 )
 
 select
@@ -34,10 +35,6 @@ select
     prod.address as prod_address,
     barn.address as barn_address,
     greatest(prod.latest_settlement, barn.latest_settlement) as latest_settlement
-from active_solvers as prod
-inner join active_solvers as barn
-    on
-        prod.name = barn.name
-        and prod.environment = 'prod'
-        and barn.environment = 'barn'
+from active_solvers as prodinner join active_solvers as barn
+    on prod.name = barn.name and prod.environment = 'prod' and barn.environment = 'barn'
 order by greatest(prod.latest_settlement, barn.latest_settlement) desc

--- a/cowprotocol/solver_dashboard/batch_settlement_info_1373033.sql
+++ b/cowprotocol/solver_dashboard/batch_settlement_info_1373033.sql
@@ -22,7 +22,11 @@ num_tokens_traded as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/solver_dashboard/batch_settlement_info_1373033.sql
+++ b/cowprotocol/solver_dashboard/batch_settlement_info_1373033.sql
@@ -11,14 +11,20 @@ num_tokens_traded as (
         select
             evt_tx_hash as tx_hash,
             "buyToken" as token
-        from gnosis_protocol_v2_{{blockchain}}.GPv2Settlement_evt_Trade
+        from gnosis_protocol_v2_{{blockchain}}.GPv2Settlement_evt_Trade --noqa: CP02
         union all
         select
             evt_tx_hash as tx_hash,
             "sellToken" as token
-        from gnosis_protocol_v2_{{blockchain}}.GPv2Settlement_evt_Trade
+        from gnosis_protocol_v2_{{blockchain}}.GPv2Settlement_evt_Trade --noqa: CP02
     ) as all_tokens
     group by tx_hash
+),
+
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
 )
 
 select
@@ -51,7 +57,6 @@ select
     end as coverage
 from cow_protocol_{{blockchain}}.batches as b
 inner join num_tokens_traded as n on b.tx_hash = n.tx_hash
-inner join cow_protocol_{{blockchain}}.solvers
-    on solver_address = address
+inner join solvers on solver_address = address
 where block_time > now() - interval '3' month
 order by block_time desc;

--- a/cowprotocol/solver_dashboard/daily_solver_stats_1847100.sql
+++ b/cowprotocol/solver_dashboard/daily_solver_stats_1847100.sql
@@ -4,6 +4,12 @@
 --   {{aggregate_by}}: string the time period to aggregate by for each solver
 --   {{blockchain}}: string the blockchain to query
 
+with solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+)
+
 select
     date_trunc('{{aggregate_by}}', block_date) as day, --noqa: RF04
     name as solver_name,
@@ -18,7 +24,7 @@ select
     1.0 * sum(gas_used) / sum(num_trades) as average_gas_per_trade,
     1.0 * sum(dex_swaps) / sum(num_trades) as average_dex_swaps_per_trade
 from cow_protocol_{{blockchain}}.batches
-inner join cow_protocol_{{blockchain}}.solvers on solver_address = address
+inner join solvers on solver_address = address
 where environment = 'prod' and block_date > now() - interval '{{last_n_days}}' day and active = True
 group by name, date_trunc('{{aggregate_by}}', block_date)
 order by num_trades desc

--- a/cowprotocol/solver_dashboard/daily_solver_stats_1847100.sql
+++ b/cowprotocol/solver_dashboard/daily_solver_stats_1847100.sql
@@ -5,7 +5,11 @@
 --   {{blockchain}}: string the blockchain to query
 
 with solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 )

--- a/cowprotocol/solver_dashboard/ranked_active_solvers_1756858.sql
+++ b/cowprotocol/solver_dashboard/ranked_active_solvers_1756858.sql
@@ -31,6 +31,12 @@ settled_batch_data as (
     inner join settled_batches as sb on b.tx_hash = sb.tx_hash
 ),
 
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+),
+
 solver_info as (
     select
         s.name as solver_name,
@@ -45,11 +51,8 @@ solver_info as (
         sum(t.surplus_usd) as total_surplus,
         1.0 * sum(b.gas_used) / nullif(sum(t.num_trades), 0) as average_gas_per_trade,
         1.0 * sum(b.dex_swaps) / nullif(sum(t.num_trades), 0) as average_dex_swaps_per_trade
-    from settled_batch_data as b
-    inner join cow_protocol_{{blockchain}}.solvers as s
-        on b.solver_address = s.address
-    inner join trade_agg as t
-        on b.tx_hash = t.tx_hash
+    from settled_batch_data as b inner join solvers as s on b.solver_address = s.address
+    inner join trade_agg as t on b.tx_hash = t.tx_hash
     where s.environment not in ('test', 'service') and s.active = TRUE
     group by s.name
 )

--- a/cowprotocol/solver_dashboard/ranked_active_solvers_1756858.sql
+++ b/cowprotocol/solver_dashboard/ranked_active_solvers_1756858.sql
@@ -32,7 +32,11 @@ settled_batch_data as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 ),

--- a/cowprotocol/solver_dashboard/solver_failures_rate_by_environment_1372870.sql
+++ b/cowprotocol/solver_dashboard/solver_failures_rate_by_environment_1372870.sql
@@ -22,7 +22,11 @@ settlement_transactions as (
 ),
 
 solvers as (
-    select *
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
     from dune.cowprotocol.solvers
     where blockchain = '{{blockchain}}'
 ),

--- a/cowprotocol/solver_dashboard/solver_failures_rate_by_environment_1372870.sql
+++ b/cowprotocol/solver_dashboard/solver_failures_rate_by_environment_1372870.sql
@@ -21,6 +21,12 @@ settlement_transactions as (
     group by "from", date_trunc('{{frequency}}', block_time)
 ),
 
+solvers as (
+    select *
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+),
+
 results as (
     select
         time,
@@ -29,8 +35,7 @@ results as (
         successes,
         failures,
         (case when successes = 0 then 0 else 1.00 * failures / (successes + failures) end) as failure_rate
-    from settlement_transactions
-    inner join cow_protocol_{{blockchain}}.solvers on solver = address
+    from settlement_transactions inner join solvers on solver = address
 )
 
 select * from results


### PR DESCRIPTION
We are finally ready to migrate to the new dune dbt `dune.cowprotocol.solvers` table, replacing the legacy dune-spellbook `cow_protocol_{{blockchain}}.solvers` table that has been slower to update.

The change is applied to several queries that have used the `cow_protocol_{{blockchain}}.solvers` table up till today