### PR TITLE
add 2 missing prices on Dune for slippage acounting on mainnet for May 26 - June 2, 2026

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -155,6 +155,8 @@ prices as (
             when '{{blockchain}}' = 'gnosis' and token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e and hour >= timestamp '2025-12-30 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f and hour >= timestamp '2026-01-13 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268
+            when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
             else price_unit
         end as price_unit,
         case
@@ -170,6 +172,8 @@ prices as (
             when '{{blockchain}}' = 'gnosis' and token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e and hour >= timestamp '2025-12-30 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f and hour >= timestamp '2026-01-13 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268 / pow(10, 18)
+            when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
             else price_atom
         end as price_atom
     from prices_pre


### PR DESCRIPTION
Reported by a solver that 2 slippage txs are not showing because of missing prices. here are the tx hashes:

`0x80b1ab83bbebe158e3f2c6ee7b8be8558d361c3ccb9da4711e902d537dc212cd`

`0xa1d04ab086c7f53ef28524af49402426784fc53e1f1624ed7b7f684608010702`

This query reveals the missing token prices: https://dune.com/queries/4059683?end_time_d7346b=2026-06-02+00%3A00%3A00&start_time_d7346b=2026-05-26+00%3A00%3A00