### PR TITLE
Fix URL for Avalanche on unusual slippage query

### DIFF
--- a/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
+++ b/cowprotocol/accounting/rewards/unusual_slippage_query_2332678.sql
@@ -15,6 +15,7 @@ url_helper as (
         case
             when '{{blockchain}}' = 'ethereum' then 'eth'
             when '{{blockchain}}' = 'bnb' then 'bsc'
+            when '{{blockchain}}' = 'avalanche_c' then 'avalanche'
             else '{{blockchain}}'
         end
 ),


### PR DESCRIPTION
# Description
This PR fixes the link to blocksec.com on the `unusual slippage` query for Avalanche.

# Context
For example, on [this query](https://dune.com/queries/2332678?end_time_d83555=2025-08-05+00%3A00%3A00&start_time_d83555=2025-07-29+00%3A00%3A00&end_time_d7346b=2026-06-09+00%3A00%3A00&start_time_d7346b=2026-06-02+00%3A00%3A00&blockchain_e559bd=avalanche_c) we can see that the url that is generated is [this](https://app.blocksec.com/explorer/tx/avalanche_c/0xA09C2E6CCDC3F3113D5A40F5D8429197BE4D3DCEDB5400FAB982AF9DD61A9413), where the correct url is [this](https://app.blocksec.com/phalcon/explorer/tx/avalanche/0xA09C2E6CCDC3F3113D5A40F5D8429197BE4D3DCEDB5400FAB982AF9DD61A9413)