### PR TITLE
Consider latest vouching event for vouching query in case of vouchings from different bonding pools

### DIFF
--- a/cowprotocol/accounting/rewards/vouch_registry_query_1541516.sql
+++ b/cowprotocol/accounting/rewards/vouch_registry_query_1541516.sql
@@ -72,13 +72,13 @@ ranked_vouches as (
 
 -- This will contain all latest active vouches,
 -- but could still contain solvers with multiplicity > 1 for different pools.
--- Rank here again by solver, and time.
+-- Rank here again by solver, and time, in decreasing order.
 current_active_vouches as (
     select
         *,
         rank() over (
             partition by solver
-            order by evt_block_number, evt_index
+            order by evt_block_number desc, evt_index desc
         ) as time_rank
     from ranked_vouches
     where
@@ -87,7 +87,7 @@ current_active_vouches as (
 ),
 
 -- To filter for the case of "same solver, different pool",
--- rank the current_active vouches and choose the earliest
+-- rank the current_active vouches and choose the latest
 valid_vouches as (
     select
         solver,


### PR DESCRIPTION
This PR updates [the vouching query](https://dune.com/queries/1541516) as follows.

Up till now, in the case of 2 valid vouches under different points pools for the same solver address, the earliest one was taken into account.

This created an issue where a solver was initially part of the CoW DAO bonding pool, and then removed themselves from the bonding pool, while the unvouching from the CoW DAO bonding pool never got executed. This caused the solver to erroneously show up as still being part of the CoW DAO bonding pool.

