### PR TITLE
Exclude batches from slippage accounting for 16-23 June 2026

### DIFF
--- a/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
+++ b/cowprotocol/accounting/rewards/excluded_batches_query_3490353.sql
@@ -294,6 +294,9 @@ where
     -- for the week of April 7 - April 14, 2026
     or tx_hash = 0x253c42dfca59cb8fcd6a198ef606033a516b29861f9cbf667ae351b566a7f8ec
 
+    -- for the week of June 16 - June 23, 2026
+    or tx_hash = 0xd02f40f7d677740e0042f2cf1bdfb4bee796e36b6092183ed13e2341879b9fcb
+
 
 -- Base
 union all


### PR DESCRIPTION
# Description
This PR excludes a transaction from slippage accounting for the week of 16 to 23 June, 2026 involving the WIN token.

# Context
https://api.cow.fi/mainnet/api/v2/solver_competition/by_tx_hash/0xD02F40F7D677740E0042F2CF1BDFB4BEE796E36B6092183ED13E2341879B9FCB

https://app.blocksec.com/phalcon/explorer/tx/eth/0xD02F40F7D677740E0042F2CF1BDFB4BEE796E36B6092183ED13E2341879B9FCB

https://explorer.cow.fi/tx/0xD02F40F7D677740E0042F2CF1BDFB4BEE796E36B6092183ED13E2341879B9FCB?tab=orders
