### PR TITLE
Un-vouched solvers approval query

### DIFF
--- a/cowprotocol/monitoring/solver_approvals_4173928.sql
+++ b/cowprotocol/monitoring/solver_approvals_4173928.sql
@@ -27,6 +27,7 @@ select --noqa: ST06
         when b.solver_address = 0x05c5494572e4ab2d48d3ab3aaf6bd4e7b1c98382 or b.solver_address = 0xd8ca5fe380b68171155c7069b8df166db28befdd then 'PROPOSER-ACCOUNT'
         else coalesce(concat(s.environment, '-', s.name), 'NON-SOLVER')
     end as responsible_solver,
+    coalesce(s.active, false) as solver_whitelisted,
     r.spender,
     r.token,
     r.value

--- a/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
+++ b/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
@@ -24,9 +24,9 @@ select
         when
             approvals.responsible_address not in (select solver from vouched_solvers)
             and not approvals.solver_whitelisted
-            then 'unvouched_and_deprecated'
+            then 'unvouched_and_blacklisted'
         when approvals.responsible_address not in (select solver from vouched_solvers) then 'unvouched'
-        when not approvals.solver_whitelisted then 'deprecated'
+        when not approvals.solver_whitelisted then 'blacklisted'
     end as flag_reason
 from approvals
 where

--- a/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
+++ b/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
@@ -1,0 +1,59 @@
+-- Flags token approvals responsible to an address that is recognized as a solver
+-- (i.e. not NON-SOLVER or PROPOSER-ACCOUNT) but whose address is not currently
+-- vouched for by a full bonding pool.
+-- Parameters:
+--  {{blockchain}} - network the query is run on
+--  {{end_time}} - end date timestamp used to determine the current vouch status
+
+with ranked as (
+    select
+        evt_tx_hash as tx_hash,
+        evt_block_time as block_time,
+        spender,
+        contract_address as token,
+        a.value,
+        rank() over (partition by spender, contract_address order by evt_block_number desc, evt_index desc) as rk
+    from erc20_{{blockchain}}.evt_approval as a
+    inner join {{blockchain}}.transactions on evt_tx_hash = hash
+    where owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
+),
+
+solvers as (
+    select
+        address,
+        environment,
+        name,
+        whitelisted as active
+    from dune.cowprotocol.solvers
+    where blockchain = '{{blockchain}}'
+),
+
+vouched_solvers as (
+    select distinct solver
+    from "query_1541516(blockchain='{{blockchain}}',end_time='{{end_time}}',vouch_cte_name='valid_vouches')"
+),
+
+approvals as (
+    select --noqa: ST06
+        r.block_time,
+        r.tx_hash,
+        b.solver_address as responsible_address,
+        case
+            when b.solver_address = 0x05c5494572e4ab2d48d3ab3aaf6bd4e7b1c98382 or b.solver_address = 0xd8ca5fe380b68171155c7069b8df166db28befdd then 'PROPOSER-ACCOUNT'
+            else coalesce(concat(s.environment, '-', s.name), 'NON-SOLVER')
+        end as responsible_solver,
+        r.spender,
+        r.token,
+        r.value
+    from ranked as r
+    inner join cow_protocol_{{blockchain}}.batches as b on r.tx_hash = b.tx_hash
+    left outer join solvers as s on b.solver_address = s.address
+    where r.rk = 1 and r.value > 0
+)
+
+select *
+from approvals
+where
+    responsible_solver not in ('NON-SOLVER', 'PROPOSER-ACCOUNT')
+    and responsible_address not in (select solver from vouched_solvers)
+order by block_time desc

--- a/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
+++ b/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
@@ -1,6 +1,7 @@
 -- Flags token approvals responsible to an address that is recognized as a solver
--- (i.e. not NON-SOLVER or PROPOSER-ACCOUNT) but whose address is not currently
--- vouched for by a full bonding pool.
+-- (i.e. not NON-SOLVER or PROPOSER-ACCOUNT) but that is either not currently
+-- vouched for by a full bonding pool, or no longer whitelisted as an active
+-- solver (e.g. deprecated/blacklisted solvers whose vouch was never revoked).
 -- Parameters:
 --  {{blockchain}} - network the query is run on
 --  {{end_time}} - end date timestamp used to determine the current vouch status
@@ -15,9 +16,23 @@ vouched_solvers as (
     from "query_1541516(blockchain='{{blockchain}}',end_time='{{end_time}}',vouch_cte_name='valid_vouches')"
 )
 
-select *
+select
+    approvals.*,
+    approvals.responsible_address not in (select solver from vouched_solvers) as is_unvouched,
+    not approvals.solver_whitelisted as is_deprecated,
+    case
+        when
+            approvals.responsible_address not in (select solver from vouched_solvers)
+            and not approvals.solver_whitelisted
+            then 'unvouched_and_deprecated'
+        when approvals.responsible_address not in (select solver from vouched_solvers) then 'unvouched'
+        when not approvals.solver_whitelisted then 'deprecated'
+    end as flag_reason
 from approvals
 where
-    responsible_solver not in ('NON-SOLVER', 'PROPOSER-ACCOUNT')
-    and responsible_address not in (select solver from vouched_solvers)
-order by block_time desc
+    approvals.responsible_solver not in ('NON-SOLVER', 'PROPOSER-ACCOUNT')
+    and (
+        approvals.responsible_address not in (select solver from vouched_solvers)
+        or not approvals.solver_whitelisted
+    )
+order by approvals.block_time desc

--- a/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
+++ b/cowprotocol/monitoring/unvouched_solver_approvals_7963030.sql
@@ -5,50 +5,14 @@
 --  {{blockchain}} - network the query is run on
 --  {{end_time}} - end date timestamp used to determine the current vouch status
 
-with ranked as (
-    select
-        evt_tx_hash as tx_hash,
-        evt_block_time as block_time,
-        spender,
-        contract_address as token,
-        a.value,
-        rank() over (partition by spender, contract_address order by evt_block_number desc, evt_index desc) as rk
-    from erc20_{{blockchain}}.evt_approval as a
-    inner join {{blockchain}}.transactions on evt_tx_hash = hash
-    where owner = 0x9008d19f58aabd9ed0d60971565aa8510560ab41
-),
-
-solvers as (
-    select
-        address,
-        environment,
-        name,
-        whitelisted as active
-    from dune.cowprotocol.solvers
-    where blockchain = '{{blockchain}}'
+with approvals as (
+    select *
+    from "query_4173928(blockchain='{{blockchain}}')"
 ),
 
 vouched_solvers as (
     select distinct solver
     from "query_1541516(blockchain='{{blockchain}}',end_time='{{end_time}}',vouch_cte_name='valid_vouches')"
-),
-
-approvals as (
-    select --noqa: ST06
-        r.block_time,
-        r.tx_hash,
-        b.solver_address as responsible_address,
-        case
-            when b.solver_address = 0x05c5494572e4ab2d48d3ab3aaf6bd4e7b1c98382 or b.solver_address = 0xd8ca5fe380b68171155c7069b8df166db28befdd then 'PROPOSER-ACCOUNT'
-            else coalesce(concat(s.environment, '-', s.name), 'NON-SOLVER')
-        end as responsible_solver,
-        r.spender,
-        r.token,
-        r.value
-    from ranked as r
-    inner join cow_protocol_{{blockchain}}.batches as b on r.tx_hash = b.tx_hash
-    left outer join solvers as s on b.solver_address = s.address
-    where r.rk = 1 and r.value > 0
 )
 
 select *


### PR DESCRIPTION
Created new query that checks token approvals from the settlement contract that were signed by recognized solvers whose addresses lack current bonding pool vouches—identifying potential risk from unverified solver signings.