### PR TITLE
Fix token price for XRP on mainnet

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -175,7 +175,6 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1A161559255aaf572F3c1cE4185578dCfE and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
             else price_atom
         end as price_atom

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -157,6 +157,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1A161559255aaf572F3c1cE4185578dCfE and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
             else price_unit
         end as price_unit,
         case
@@ -174,6 +175,8 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1A161559255aaf572F3c1cE4185578dCfE and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
             else price_atom
         end as price_atom
     from prices_pre

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -157,7 +157,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1A161559255aaf572F3c1cE4185578dCfE and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
             else price_unit
         end as price_unit,
         case
@@ -175,7 +175,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1A161559255aaf572F3c1cE4185578dCfE and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
             else price_atom
         end as price_atom
     from prices_pre


### PR DESCRIPTION
Price of token at time of the trade:
<img width="1537" height="695" alt="image" src="https://github.com/user-attachments/assets/6c70cd74-3435-4b75-b456-8d8eaf008e49" />

XRP price crashed to 0$:
<img width="1324" height="610" alt="image" src="https://github.com/user-attachments/assets/20cafa63-d80c-4c46-8d8a-6ff61598e4e7" />

This pr updates XRP price to 0 so the slippage for this auction shows up correctly: https://app.blocksec.com/phalcon/explorer/tx/eth/0xD8AA34716F49DD0C7F34608AA959F24E71CD7EF51FB2828923AA0EAF42DE9E65