### PR TITLE
 Fix inflated slippage price for FTM (0x4E15361FD6b4BB609Fa63C81A2be19d873717870) on 2026-07-30

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -158,7 +158,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.02755299152708287 -- noqa:CP02
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.0284 -- noqa:CP02
             else price_unit
         end as price_unit,
         case
@@ -177,7 +177,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.02755299152708287 / pow(10, 18) -- noqa:CP02
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.0284 / pow(10, 18) -- noqa:CP02
             else price_atom
         end as price_atom
     from prices_pre

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -158,6 +158,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.02755299152708287 -- noqa:CP02
             else price_unit
         end as price_unit,
         case
@@ -176,6 +177,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.02755299152708287 / pow(10, 18) -- noqa:CP02
             else price_atom
         end as price_atom
     from prices_pre

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -158,7 +158,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 18:00' then 0.0284 -- noqa:CP02
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.0284 -- noqa:CP02
             else price_unit
         end as price_unit,
         case
@@ -177,7 +177,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 18:00' then 0.0284 / pow(10, 18) -- noqa:CP02
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.0284 / pow(10, 18) -- noqa:CP02
             else price_atom
         end as price_atom
     from prices_pre

--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -158,7 +158,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.0284 -- noqa:CP02
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 18:00' then 0.0284 -- noqa:CP02
             else price_unit
         end as price_unit,
         case
@@ -177,7 +177,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x60d48c1a161559255aaf572f3c1ce4185578dcfe and hour >= timestamp '2026-07-14 13:00' and hour <= timestamp '2026-07-14 14:00' then 0.0
-            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 10:00' then 0.0284 / pow(10, 18) -- noqa:CP02
+            when '{{blockchain}}' = 'ethereum' and token_address = 0x4e15361fd6b4bb609fa63c81a2be19d873717870 and hour >= timestamp '2026-07-30 09:00' and hour <= timestamp '2026-07-30 18:00' then 0.0284 / pow(10, 18) -- noqa:CP02
             else price_atom
         end as price_atom
     from prices_pre


### PR DESCRIPTION
 Fix inflated slippage price for FTM (0x4E15361FD6b4BB609Fa63C81A2be19d873717870) on 2026-07-30

Tx 0x0ED0B2A9875D2CB6BFCAEDE24DDAAEC9066EF1613B8D59A7FCEC7ED68363BD5B on mainnet reported ~$125 slippage while only ~$10 of value actually moved to the settlement contract.
This way cause by a spike that increased its price to ~$0.032 vs the ~$0.0275–0.0286 average. The spike was caused by the low volume of the token.
This pr adds a manual price override that reflects the correct price that should be used at that time.

Tx: https://app.blocksec.com/phalcon/explorer/tx/eth/0x0ED0B2A9875D2CB6BFCAEDE24DDAAEC9066EF1613B8D59A7FCEC7ED68363BD5B

<img width="922" height="557" alt="image" src="https://github.com/user-attachments/assets/b79daae5-be6d-49fa-8c25-f1adeee095f0" />
