### PR TITLE
Fix slippage query for GBP token

### DIFF
--- a/cowprotocol/accounting/fees/classified_fees_4058574.sql
+++ b/cowprotocol/accounting/fees/classified_fees_4058574.sql
@@ -43,6 +43,7 @@ protocol_fees as (
         case
             when '{{blockchain}}' = 'ethereum' and protocol_fee_token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f then 0x39b8b6385416f4ca36a20319f70d28621895279d
             when '{{blockchain}}' = 'gnosis' and protocol_fee_token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e then 0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430
+            when '{{blockchain}}' = 'gnosis' and sell_token_address = 0x5cb9073902f2035222b9749f8fb0c9bfe5527108 then 0x8e34bfec4f6eb781f9743d9b4af99cd23f9b7053
             else protocol_fee_token_address
         end as token_address,
         protocol_fee as amount,

--- a/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
+++ b/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
@@ -62,7 +62,7 @@ settlement_contract_sells as (
         case
             when '{{blockchain}}' = 'ethereum' and sell_token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f then 0x39b8b6385416f4ca36a20319f70d28621895279d
             when '{{blockchain}}' = 'gnosis' and sell_token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e then 0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430
-            when '{{blockchain}}' = 'gnosis' and sell_token_address = 0x5cb9073902f2035222b9749f8fb0c9bfe5527108 then 0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053
+            when '{{blockchain}}' = 'gnosis' and sell_token_address = 0x5cb9073902f2035222b9749f8fb0c9bfe5527108 then 0x8e34bfec4f6eb781f9743d9b4af99cd23f9b7053
             else sell_token_address
         end as token_address,
         atoms_sold as amount,

--- a/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
+++ b/cowprotocol/accounting/slippage/raw_slippage_4059683.sql
@@ -62,6 +62,7 @@ settlement_contract_sells as (
         case
             when '{{blockchain}}' = 'ethereum' and sell_token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f then 0x39b8b6385416f4ca36a20319f70d28621895279d
             when '{{blockchain}}' = 'gnosis' and sell_token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e then 0x420ca0f9b9b604ce0fd9c18ef134c705e5fa3430
+            when '{{blockchain}}' = 'gnosis' and sell_token_address = 0x5cb9073902f2035222b9749f8fb0c9bfe5527108 then 0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053
             else sell_token_address
         end as token_address,
         atoms_sold as amount,


### PR DESCRIPTION
# Description
This PR updates the slippage query to consider both GBP v1 and v2 as the same token.

# Context
Token addresses can be verified in the docs: https://docs.monerium.com/tokens/
