### PR TITLE
Fix condition in skipped bridge alert

### DIFF
--- a/cowprotocol/alerts/hooks/skipped_hooks_5534339.sql
+++ b/cowprotocol/alerts/hooks/skipped_hooks_5534339.sql
@@ -33,7 +33,7 @@ with all_hooks as (
 select * 
 from all_hooks
 where 
-    coalesce(hook_success,false) = false
+    hook_success is null
     and not( hook_app_id in (
         'cow-swap://libs/hook-dapp-lib/permit',
         'PERMIT_TOKEN',


### PR DESCRIPTION
we already have a [failed bridge alert](https://github.com/cowprotocol/dune-queries/blob/main/cowprotocol/alerts/hooks/failed_bridges_5552265.sql), so this one does not need the coalesce