### PR TITLE
Set price of GBPe v1 to 0 after July 28, 2026

### DIFF
--- a/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
+++ b/cowprotocol/accounting/slippage/slippage_prices_4064601.sql
@@ -154,6 +154,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56 and hour >= timestamp '2025-12-30 03:00' and hour <= timestamp '2025-12-30 04:00' then 2.8 -- noqa:CP02
             when '{{blockchain}}' = 'gnosis' and token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e and hour >= timestamp '2025-12-30 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f and hour >= timestamp '2026-01-13 00:00' then 0.0
+            when '{{blockchain}}' = 'gnosis' and token_address = 0x5cb9073902f2035222b9749f8fb0c9bfe5527108 and hour >= timestamp '2026-07-28 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105
@@ -173,6 +174,7 @@ prices as (
             when '{{blockchain}}' = 'ethereum' and token_address = 0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56 and hour >= timestamp '2025-12-30 03:00' and hour <= timestamp '2025-12-30 04:00' then 2.8 / pow(10, 18) -- noqa:CP02
             when '{{blockchain}}' = 'gnosis' and token_address = 0xcb444e90d8198415266c6a2724b7900fb12fc56e and hour >= timestamp '2025-12-30 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x3231cb76718cdef2155fc47b5286d82e6eda273f and hour >= timestamp '2026-01-13 00:00' then 0.0
+            when '{{blockchain}}' = 'gnosis' and token_address = 0x5cb9073902f2035222b9749f8fb0c9bfe5527108 and hour >= timestamp '2026-07-28 00:00' then 0.0
             when '{{blockchain}}' = 'ethereum' and token_address = 0x4956b52ae2ff65d74ca2d61207523288e4528f96 and hour >= timestamp '2026-03-22 15:00' and hour <= timestamp '2026-03-22 19:00' then 0.23292903653351268 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0xfcc5c47be19d06bf83eb04298b026f81069ff65b and hour >= timestamp '2026-05-27 09:00' and hour <= timestamp '2026-05-27 10:00' then 0.133 / pow(10, 18)
             when '{{blockchain}}' = 'ethereum' and token_address = 0x01791f726b4103694969820be083196cc7c045ff and hour >= timestamp '2026-05-27 10:00' and hour <= timestamp '2026-05-27 11:00' then 0.105 / pow(10, 18)


### PR DESCRIPTION
# Description
This PR sets the price of GBPe v1 to 0 after the accounting week of July 28, 2026. Following on PR #367 

# Context
Similar PR for EURe: https://github.com/cowprotocol/dune-queries/pull/315/changes